### PR TITLE
Add support for multiple storage backends

### DIFF
--- a/pthreadfs/README.md
+++ b/pthreadfs/README.md
@@ -5,6 +5,8 @@ The Emscripten Pthread File System (PThreadFS) unlocks using (partly) asynchrono
 PThreadFS works by replacing Emscripten's file system API with a new API that proxies all file system operations to a dedicated pthread. This dedicated thread maintains a virtual file system that can use different APIs as backend (very similar to the way Emscripten's VFS is designed). In particular, PThreadFS comes with built-in support for asynchronous backends such as [OPFS Access Handles](https://docs.google.com/document/d/121OZpRk7bKSF7qU3kQLqAEUVSNxqREnE98malHYwWec/edit#heading=h.gj2fudnvy982).
 Although the underlying storage API is asynchronous, PThreadFS makes it appear synchronous to the C++ application.
 
+If OPFS Access Handles are not available, PThreadFS will attempt to use the [Storage Foundation API](https://github.com/WICG/storage-foundation-api-explainer). As a last fallback, Emscripten's MEMFS in-memory file system is used.
+
 The code is still prototype quality and **should not be used in a production environment** for the time being.
 
 ## Enable and detect OPFS in Chrome
@@ -69,7 +71,7 @@ In order to use the code in a new project, you only need the three files in the 
 #include "pthreadfs.h"
 ```
 - Call `emscripten_init_pthreadfs();` at the top of `main()` (or before any file system syscalls).
-- PThreadFS maintains a virtual file system. The OPFS backend is mounted at `/filesystemaccess/`. Only files in this folder are persisted between sessions. All other files will be stored in-memory through MEMFS.
+- PThreadFS maintains a virtual file system. The OPFS backend is mounted at `/pthreadfs/`. Only files in this folder are persisted between sessions. All other files will be stored in-memory through MEMFS.
 
 ### Build process changes
 
@@ -102,8 +104,8 @@ See `pthreadfs/examples/emscripten-tests/fsafs.cpp` for exemplary usage.
 
 ## Known Limitations
 
-- All files to be stored using the file system access Access Handles must be stored in the `/filesystemaccess` folder.
-- Files in the `/filesystemaccess` folder cannot interact through syscalls with other files (e.g. moving, copying, etc.).
+- All files to be stored using the file system access Access Handles must be stored in the `/pthreadfs` folder.
+- Files in the `/pthreadfs` folder cannot interact through syscalls with other files (e.g. moving, copying, etc.).
 - The code is still prototype quality and **should not be used in a production environment** yet. It is possible that the use of PThreadFS might lead to subtle bugs in other libraries.
 - PThreadFS requires PROXY_TO_PTHREAD to be active. In particular, no system calls interacting with the file system should be called from the main thread.
 - Some functionality of the Emscripten File System API is missing, such as sockets, IndexedDB integration and support for XHRequests.

--- a/pthreadfs/examples/emscripten-tests/fsafs.cpp
+++ b/pthreadfs/examples/emscripten-tests/fsafs.cpp
@@ -7,32 +7,31 @@
 
 int main () {
   emscripten_init_pthreadfs();
-  std::cout << "std::cout works fine.\n";
+  std::cout << "Proof that stdout works fine.\n";
   std::ofstream myfile;
-  myfile.open ("filesystemaccess/example");
-  myfile << "Writing a few characters to the example file.\n";
+  myfile.open ("pthreadfs/example");
+  myfile << "Writing a few characters.\n";
   myfile.close();
 
   std::string line;
-  std::ifstream myfile_read ("filesystemaccess/example");
+  std::ifstream myfile_read ("pthreadfs/example");
  
   if (myfile_read.is_open()) {
     std::getline(myfile_read, line);
-    EM_ASM({
-      console.log("Read line " + UTF8ToString($0));
+    EM_ASM({console.log("Read line" + UTF8ToString($0));
     }, line.c_str());
     myfile_read.close();
   }
 
-  std::ofstream stream1 ("filesystemaccess/multistreamexample");
-  std::ofstream stream2 ("filesystemaccess/multistreamexample");
+  std::ofstream stream1 ("pthreadfs/multistreamexample");
+  std::ofstream stream2 ("pthreadfs/multistreamexample");
   stream1 << "Write a line through stream1.\n";
   stream2 << "Write a line through stream2.\n";
   stream1.close();
   stream2.close();
 
-  std::remove("filesystemaccess/multistreamexample"); 
-  bool can_open_deleted_file = (bool) std::ifstream("filesystemaccess/multistreamexample");
+  std::remove("pthreadfs/multistreamexample"); 
+  bool can_open_deleted_file = (bool) std::ifstream("pthreadfs/multistreamexample");
   if(!can_open_deleted_file) { 
     std::cout << "Opening deleted file failed, as expected.\n"; 
   }

--- a/pthreadfs/examples/emscripten-tests/multiple_threads.cpp
+++ b/pthreadfs/examples/emscripten-tests/multiple_threads.cpp
@@ -11,7 +11,7 @@
 void threadMain(int msg) {
   size_t thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
   std::ofstream myfile;
-  myfile.open ("filesystemaccess/multi_threading_example", std::ios_base::app);
+  myfile.open ("pthreadfs/multi_threading_example", std::ios_base::app);
   myfile << "Writing from thread " << msg << " Id: " << thread_id << "   ";
   myfile.close();
   EM_ASM({console.log(`Wrote on thread ${$0}`);}, thread_id);
@@ -21,7 +21,7 @@ void threadMain(int msg) {
 int main () {
   emscripten_init_pthreadfs();
   EM_ASM({console.log("Hello from main")});
-  std::remove("filesystemaccess/multi_threading_example"); 
+  std::remove("pthreadfs/multi_threading_example"); 
 
   constexpr int number_of_threads = 10;
 
@@ -35,7 +35,7 @@ int main () {
   }
 
   std::ofstream myfile;
-  myfile.open ("filesystemaccess/multi_threading_example");
+  myfile.open ("pthreadfs/multi_threading_example");
   myfile << "Writing the main thread.\n";
   myfile.close();
   

--- a/pthreadfs/examples/sqlite-speedtest/sqlite-speedtest-prejs.js
+++ b/pthreadfs/examples/sqlite-speedtest/sqlite-speedtest-prejs.js
@@ -3,4 +3,4 @@ var Module = Module || {};
 Module['arguments'] = Module['arguments'] || [];
 Module['arguments'].push('--size');
 Module['arguments'].push('40');
-Module['arguments'].push(`/filesystemaccess/db${Math.random()}`);
+Module['arguments'].push(`/pthreadfs/db${Math.random()}`);

--- a/pthreadfs/library_pthreadfs.js
+++ b/pthreadfs/library_pthreadfs.js
@@ -56,7 +56,7 @@ function createWasiWrapper(name, args, wrappers) {
   wrapper += `_fd_${name}_async(${full_args}).then((res) => {`;
   wrapper += 'wasmTable.get(resume)(res);});}'
   wrappers[`__fd_${name}_async`] = eval('(' + wrapper + ')');
-  wrappers[`__fd_${name}_async__deps`] = [`fd_${name}_async`, '$ASYNCSYSCALLS', '$FSAFS'];
+  wrappers[`__fd_${name}_async__deps`] = [`fd_${name}_async`, '$ASYNCSYSCALLS', '$FSAFS', '$SFAFS'];
 }
 
 function createSyscallWrapper(name, args, wrappers) {
@@ -70,7 +70,7 @@ function createSyscallWrapper(name, args, wrappers) {
   wrapper += `_${name}_async(${full_args}).then((res) => {`;
   wrapper += 'wasmTable.get(resume)(res);});}'
   wrappers[`__sys_${name}_async`] = eval('(' + wrapper + ')');
-  wrappers[`__sys_${name}_async__deps`] = [`${name}_async`, '$ASYNCSYSCALLS', '$FSAFS'];
+  wrappers[`__sys_${name}_async__deps`] = [`${name}_async`, '$ASYNCSYSCALLS', '$FSAFS', '$SFAFS'];
 }
 
 for (x of WasiFunctions) {
@@ -133,32 +133,59 @@ SyscallWrappers['init_pthreadfs'] = function (resume) {
   });
 }
 
-SyscallWrappers['init_fsafs'] = function(resume) {
-  PThreadFS.mkdir('/filesystemaccess').then(async () => {
-    await PThreadFS.mount(FSAFS, { root: '.' }, '/filesystemaccess');
+// Initialize a backend for PThreadFS.
+// PThreadFS can only work with a single backend at a time. The initialization code
+// checks which backends are available and picks from the following list:
+// 1. OPFS Access Handles - see https://github.com/WICG/file-system-access/blob/main/AccessHandle.md
+// 2. Storage Foundation API - https://github.com/WICG/storage-foundation-api-explainer
+// 3. Emscripten's in-Memory file system (MEMFS).
+SyscallWrappers['init_backend'] = function(resume) {
+
+  let access_handle_detection = async function() {
+    const root = await navigator.storage.getDirectory();
+    const file = await root.getFileHandle('access-handle-detect', { create: true });
+    const present = file.createSyncAccessHandle != undefined;
+    await root.removeEntry('access-handle-detect');
+    return present;
+  }
+
+  let storage_foundation_detection = function() {
+    if (typeof storageFoundation == typeof undefined) {
+      return false;
+    }
+    if (storageFoundation.requestCapacitySync(1) === 0) {
+      return false;
+    }
+    return true;
+  }
+
+  PThreadFS.mkdir('/pthreadfs').then(async () => {
+    let has_access_handles = await access_handle_detection();
+    let has_storage_foundation = storage_foundation_detection();
+
+    if (has_access_handles) {
+      await PThreadFS.mount(FSAFS, { root: '.' }, '/pthreadfs');
+      console.log('Initialized PThreadFS with OPFS Access Handles');
+      wasmTable.get(resume)();
+      return;
+    }
+    if (has_storage_foundation) {
+      await PThreadFS.mount(SFAFS, { root: '.' }, '/pthreadfs');
+  
+      // Storage Foundation requires explicit capacity allocations.
+      if (storageFoundation.requestCapacity) {
+        await storageFoundation.requestCapacity(1024*1024*1024);
+      }
+      console.log('Initialized PThreadFS with Storage Foundation API');
+      wasmTable.get(resume)();
+      return;
+    }
+    console.log('Initialized PThreadFS with MEMFS');
     wasmTable.get(resume)();
   });
 }
 
-SyscallWrappers['init_sfafs'] = function(resume) {
-  PThreadFS.mkdir('/sfa').then(async () => {
-    await PThreadFS.mount(SFAFS, { root: '.' }, '/sfa');
-
-    // Storage Foundation requires explicit capacity allocations.
-    if (storageFoundation.requestCapacity) {
-      await storageFoundation.requestCapacity(1024*1024*100);
-    }
-    // Delete all old files.
-    let files = await storageFoundation.getAll();
-    for (file of files) {
-      await storageFoundation.delete(file);
-    }
-    wasmTable.get(resume)();
-  });
-}
-
-mergeInto(LibraryManager.library, SyscallWrappers);
-/**
+mergeInto(LibraryManager.library, SyscallWrappers);/**
  * @license
  * Copyright 2013 The Emscripten Authors
  * SPDX-License-Identifier: MIT
@@ -2910,6 +2937,430 @@ mergeInto(LibraryManager.library, {
         // should we check if bytesWritten and length are the same?
         return 0;
       }
+    }
+  }
+});
+/**
+ * @license
+ * Copyright 2021 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+mergeInto(LibraryManager.library, {
+  $SFAFS__deps: ['$PThreadFS'],
+  $SFAFS: {
+
+    benchmark: function(name, fct) {
+      if('benchmark_results' in Module) {
+        let time_pre = performance.now();
+        let result = fct();
+        let time_needed = performance.now() - time_pre;
+
+        Module.benchmark_results[`${name}_time`] = (Module.benchmark_results[`${name}_time`] || 0) + time_needed;
+        Module.benchmark_results[`${name}_num`] = (Module.benchmark_results[`${name}_num`] || 0) + 1;
+        return result;
+      }
+      return fct();
+    },
+
+    /* Debugging */
+
+    debug: function(...args) {
+      // Uncomment to print debug information.
+      //
+      // console.log('SFAFS', arguments);
+    },
+
+    /* Helper functions */
+
+    realPath: function(node) {
+      var parts = [];
+      while (node.parent !== node) {
+        parts.push(node.name);
+        node = node.parent;
+      }
+      if (!parts.length) {
+        return '_';
+      }
+      parts.push('');
+      parts.reverse();
+      return parts.join('_');
+    },
+
+    encodedPath: function(node) {
+      return SFAFS.encodePath(SFAFS.realPath(node));
+    },
+
+    joinPaths: function(path1, path2) {
+      if (path1.endsWith('_')) {
+        if (path2.startsWith('_')) {
+          return path1.slice(0, -1) + path2;
+        }
+        return path1 + path2;
+      } else {
+        if (path2.startsWith('_')) {
+          return path1 + path2;
+        }
+        return path1 + '_' + path2;
+      }
+    },
+
+    // directoryPath ensures path ends with a path delimiter ('_').
+    //
+    // Example:
+    // * directoryPath('_dir') = '_dir_'
+    // * directoryPath('_dir_') = '_dir_'
+    directoryPath: function(path) {
+      if (path.length && path.slice(-1) == '_') {
+        return path;
+      }
+      return path + '_';
+    },
+
+    // extractFilename strips the parent path and drops suffixes after '_'.
+    //
+    // Example:
+    // * extractFilename('_dir', '_dir_myfile') = 'myfile'
+    // * extractFilename('_dir', '_dir_mydir_myfile') = 'mydir'
+    extractFilename: function(parent, path) {
+      parent = SFAFS.directoryPath(parent);
+      path = path.substr(parent.length);
+      var index = path.indexOf('_');
+      if (index == -1) {
+        return path;
+      }
+      return path.substr(0, index);
+    },
+
+    encodePath: function(path) {
+      //TODO: this is a random hex encoding decide and document on reasonable
+      //scheme
+      var s = unescape(encodeURIComponent(path))
+      var h = ''
+      for (var i = 0; i < s.length; i++) {
+          h += s.charCodeAt(i).toString(16)
+      }
+      return h
+    },
+
+    decodePath: function(hex) {
+      var s = ''
+      for (var i = 0; i < hex.length; i+=2) {
+          s += String.fromCharCode(parseInt(hex.substr(i, 2), 16))
+      }
+      return decodeURIComponent(escape(s))
+    },
+
+
+    listByPrefix: async function(prefix) {
+      entries = await storageFoundation.getAll();
+      return entries.filter(name => name.startsWith(prefix))
+    },
+
+    // Caches open file handles to simulate opening a file multiple times.
+    openFileHandles: {},
+
+    /* Filesystem implementation (public interface) */
+
+    createNode: function (parent, name, mode, dev) {
+      SFAFS.debug('createNode', arguments);
+      if (!PThreadFS.isDir(mode) && !PThreadFS.isFile(mode)) {
+        throw new PThreadFS.ErrnoError({{{ cDefine('EINVAL') }}});
+      }
+      var node = PThreadFS.createNode(parent, name, mode);
+      node.node_ops = SFAFS.node_ops;
+      node.stream_ops = SFAFS.stream_ops;
+      if (PThreadFS.isDir(mode)) {
+        node.contents = {};
+      }
+      node.timestamp = Date.now();
+      return node;
+    },
+
+    mount: function (mount) {
+      SFAFS.debug('mount', arguments);
+      return SFAFS.createNode(null, '/', {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */, 0);
+    },
+
+    cwd: function() { return process.cwd(); },
+
+    chdir: function() { process.chdir.apply(void 0, arguments); },
+
+    allocate: function() {
+      SFAFS.debug('allocate', arguments);
+      throw new PThreadFS.ErrnoError({{{ cDefine('EOPNOTSUPP') }}});
+    },
+
+    ioctl: function() {
+      SFAFS.debug('ioctl', arguments);
+      throw new PThreadFS.ErrnoError({{{ cDefine('ENOTTY') }}});
+    },
+
+    /* Operations on the nodes of the filesystem tree */
+
+    node_ops: {
+      getattr: async function(node) {
+        SFAFS.debug('getattr', arguments);
+        let length;
+        if (node.handle) {
+          length = await node.handle.getLength();
+        } 
+        else {
+          // TODO: this double caching of opened files is probably redundant.
+          // Clean up after publishing a clean design for the PThreadFS.
+          var path = SFAFS.realPath(node);
+          if(path in SFAFS.openFileHandles) {
+            let fileHandle = SFAFS.openFileHandles[path]
+            length = await fileHandle.getLength();
+          } 
+          else {
+            let fileHandle = await storageFoundation.open(SFAFS.encodePath(path));
+            length = await fileHandle.getLength();
+            await fileHandle.close();
+          }
+        }
+
+        let modificationTime = new Date(node.timestamp);
+        return {
+          dev: null,
+          ino: null,
+          mode: node.mode,
+          nlink: 1,
+          uid: 0,
+          gid: 0,
+          rdev: null,
+          size: length,
+          atime: modificationTime,
+          mtime: modificationTime,
+          ctime: modificationTime,
+          blksize: 4096,
+          blocks: Math.ceil(length / 4096),
+        };
+      },
+
+      setattr: async function(node, attr) {
+        SFAFS.debug('setattr', arguments);
+        if (attr.mode !== undefined) {
+          node.mode = attr.mode;
+        }
+        if (attr.timestamp !== undefined) {
+          node.timestamp = attr.timestamp;
+        }
+        if (attr.size !== undefined) {
+          let useOpen = false;
+          let fileHandle = node.handle;
+          try {
+            if (!fileHandle) {
+              // Open a handle that is closed later.
+              useOpen = true;
+              fileHandle = await storageFoundation.open(SFAFS.encodedPath(node));
+            }
+            await fileHandle.setLength(attr.size);
+            
+          } catch (e) {
+            if (!('code' in e)) throw e;
+            throw new PThreadFS.ErrnoError(-e.errno);
+          } finally {
+            if (useOpen) {
+              await fileHandle.close();
+            }
+          }
+        }
+      },
+
+      lookup: async function (parent, name) {
+        SFAFS.debug('lookup', arguments);
+        var parentPath = SFAFS.directoryPath(SFAFS.realPath(parent));
+
+        var children = await SFAFS.listByPrefix(parentPath);
+
+        var exists = false;
+        var mode = 511 /* 0777 */
+        for (var i = 0; i < children.length; ++i) {
+          var path = children[i].substr(parentPath.length);
+          if (path == name) {
+            exists = true;
+            mode |= {{{ cDefine('S_IFREG') }}};
+            break;
+          }
+
+          subdirName = SFAFS.directoryPath(name);
+          if (path.startsWith(subdirName)) {
+            exists = true;
+            mode |= {{{ cDefine('S_IFDIR') }}};
+            break;
+          }
+        }
+
+        if (!exists) {
+          throw PThreadFS.genericErrors[{{{ cDefine('ENOENT') }}}];
+        }
+
+        var node = PThreadFS.createNode(parent, name, mode);
+        node.node_ops = SFAFS.node_ops;
+        node.stream_ops = SFAFS.stream_ops;
+        return node;
+      },
+
+      mknod: function (parent, name, mode, dev) {
+        SFAFS.debug('mknod', arguments);
+        var node = SFAFS.createNode(parent, name, mode, dev);
+        if (!PThreadFS.isFile) {
+          console.log('SFAFS error: mknod is only implemented for files')
+          throw new PThreadFS.ErrnoError({{{ cDefine('ENOSYS') }}});
+        }
+
+        node.handle = null;
+        node.refcount = 0;
+        return node;
+      },
+
+      rename: function (oldNode, newParentNode, newName) {
+        // TODO(rstz): Use storageFoundation.rename() to implement this.
+        SFAFS.debug('rename', arguments);
+        console.log('SFAFS error: rename is not implemented')
+        throw new PThreadFS.ErrnoError({{{ cDefine('ENOSYS') }}});
+      },
+
+      unlink: async function(parent, name) {
+        SFAFS.debug('unlink', arguments);
+        var path = SFAFS.joinPaths(SFAFS.realPath(parent), name);
+        return await storageFoundation.delete(SFAFS.encodePath(path));
+      },
+
+      rmdir: function(parent, name) {
+        SFAFS.debug('rmdir', arguments);
+        console.log('SFAFS error: rmdir is not implemented')
+        throw new PThreadFS.ErrnoError({{{ cDefine('ENOSYS') }}});
+      },
+
+      readdir: async function(node) {
+        SFAFS.debug('readdir', arguments);
+        var parentPath = SFAFS.realPath(node);
+        var children = await SFAFS.listByPrefix(SFAFS.encodePath(parentPath));
+        children = children.map(child => SFAFS.extractFilename(parentPath, child));
+        // Remove duplicates.
+        return Array.from(new Set(children));
+      },
+
+      symlink: function(parent, newName, oldPath) {
+        console.log('SFAFS error: symlink is not implemented')
+        throw new PThreadFS.ErrnoError({{{ cDefine('ENOSYS') }}});
+      },
+
+      readlink: function(node) {
+        console.log('SFAFS error: readlink is not implemented')
+        throw new PThreadFS.ErrnoError({{{ cDefine('ENOSYS') }}});
+      },
+    },
+
+    /* Operations on file streams (i.e., file handles) */
+
+    stream_ops: {
+      open: async function (stream) {
+        SFAFS.debug('open', arguments);
+        if (!PThreadFS.isFile(stream.node.mode)) {
+          console.log('SFAFS error: open is only implemented for files')
+          throw new PThreadFS.ErrnoError({{{ cDefine('ENOSYS') }}});
+        }
+
+        if (stream.node.handle) {
+          //TODO: check when this code path is actually executed, it seems to
+          //duplicate some of the caching behavior below.
+          stream.handle = stream.node.handle;
+          ++stream.node.refcount;
+        } else {
+          var path = SFAFS.realPath(stream.node);
+
+          // Open existing file.
+          if(!(path in SFAFS.openFileHandles)) {
+            SFAFS.openFileHandles[path] = await storageFoundation.open(SFAFS.encodePath(path));
+          }
+          stream.handle = SFAFS.openFileHandles[path];
+          stream.node.handle = stream.handle;
+          stream.node.refcount = 1;
+        }
+        SFAFS.debug('end open');
+      },
+
+      close: async function (stream) {
+        SFAFS.debug('close', arguments);
+        if (!PThreadFS.isFile(stream.node.mode)) {
+          console.log('SFAFS error: close is only implemented for files');
+          throw new PThreadFS.ErrnoError({{{ cDefine('ENOSYS') }}});
+        }
+
+        stream.handle = null;
+        --stream.node.refcount;
+        if (stream.node.refcount <= 0) {
+          await stream.node.handle.close();
+          stream.node.handle = null;
+          delete SFAFS.openFileHandles[SFAFS.realPath(stream.node)];
+        }
+        SFAFS.debug('end close');
+      },
+
+      fsync: async function(stream) {
+        SFAFS.debug('fsync', arguments);
+        if (stream.handle == null) {
+          throw new PThreadFS.ErrnoError({{{ cDefine('EBADF') }}});
+        }
+        await stream.handle.flush();
+        SFAFS.debug('end fsync');
+        return 0;
+      },
+
+      read: async function (stream, buffer, offset, length, position) {
+        SFAFS.debug('read', arguments);
+        let data = new Uint8Array(length);
+        let result = await stream.handle.read(data, position);
+        buffer.set(result.buffer, offset);
+        SFAFS.debug('end read');
+        return result.readBytes;
+      },
+
+      write: async function (stream, buffer, offset, length, position) {
+        SFAFS.debug('write', arguments);
+        stream.node.timestamp = Date.now();
+        let data = new Uint8Array(buffer.slice(offset, offset+length));
+        let result = await stream.handle.write(data, position);
+        SFAFS.debug('end write');
+        return result.writtenBytes;
+      },
+
+      llseek: async function (stream, offset, whence) {
+        SFAFS.debug('llseek', arguments);
+        var position = offset;
+        if (whence === 1) {  // SEEK_CUR.
+          position += stream.position;
+        } else if (whence === 2) {  // SEEK_END.
+          position += await stream.handle.getLength();
+        } else if (whence !== 0) {  // SEEK_SET.
+          throw new PThreadFS.ErrnoError({{{ cDefine('EINVAL') }}});
+        }
+
+        if (position < 0) {
+          throw new PThreadFS.ErrnoError({{{ cDefine('EINVAL') }}});
+        }
+        stream.position = position;
+        SFAFS.debug('end llseek');
+        return position;
+      },
+
+      mmap: function(stream, buffer, offset, length, position, prot, flags) {
+        SFAFS.debug('mmap', arguments);
+        throw new PThreadFS.ErrnoError({{{ cDefine('EOPNOTSUPP') }}});
+      },
+
+      msync: function(stream, buffer, offset, length, mmapFlags) {
+        SFAFS.debug('msync', arguments);
+        throw new PThreadFS.ErrnoError({{{ cDefine('EOPNOTSUPP') }}});
+      },
+
+      munmap: function(stream) {
+        SFAFS.debug('munmap', arguments);
+        throw new PThreadFS.ErrnoError({{{ cDefine('EOPNOTSUPP') }}});
+      },
     }
   }
 });

--- a/pthreadfs/pthreadfs.cpp
+++ b/pthreadfs/pthreadfs.cpp
@@ -152,7 +152,7 @@ WASI_CAPI_NOARGS_DEF(sync) {
 SYS_CAPI_DEF(open, 5, long path, long flags, ...) {
   
   std::string pathname((char*) path);
-  if (pathname.rfind("/filesystemaccess", 0) == 0 || pathname.rfind("filesystemaccess", 0) == 0) {
+  if (pathname.rfind("/pthreadfs", 0) == 0 || pathname.rfind("pthreadfs", 0) == 0) {
     va_list vl;
     va_start(vl, flags);
     mode_t mode = va_arg(vl, mode_t);
@@ -302,7 +302,7 @@ void emscripten_init_pthreadfs() {
   });
   g_synctoasync_helper.doWork([](SyncToAsync::Callback resume) {
     g_resumeFct = [resume]() { resume(); };
-    init_fsafs(&resumeWrapper_v);
+    init_backend(&resumeWrapper_v);
   });
   return;
 }

--- a/pthreadfs/pthreadfs.h
+++ b/pthreadfs/pthreadfs.h
@@ -69,7 +69,7 @@
   return __sys_##name(__VA_ARGS__);
 #define SYS_SYNCTOASYNC_PATH(name, ...) \
   std::string pathname((char*) path); \
-  if (pathname.rfind("/filesystemaccess", 0) == 0 || pathname.rfind("filesystemaccess", 0) == 0) { \
+  if (pathname.rfind("/pthreadfs", 0) == 0 || pathname.rfind("pthreadfs", 0) == 0) { \
     g_synctoasync_helper.doWork([__VA_ARGS__](SyncToAsync::Callback resume) { \
       g_resumeFct = [resume]() { resume(); }; \
       __sys_##name##_async(__VA_ARGS__, &resumeWrapper_l); \
@@ -81,8 +81,7 @@
 extern "C" {
   // Helpers
   extern void init_pthreadfs(void (*fun)(void));
-  extern void init_sfafs(void (*fun)(void));
-  extern void init_fsafs(void (*fun)(void));
+  extern void init_backend(void (*fun)(void));
   void emscripten_init_pthreadfs();
 
   // WASI

--- a/pthreadfs/src/Makefile
+++ b/pthreadfs/src/Makefile
@@ -9,6 +9,6 @@ LIB_SFAFS = $(JSLIB_SRC)/library_sfafs_async.js
 LIB_FSAFS = $(JSLIB_SRC)/library_fsafs.js
 LIB_TTY = $(JSLIB_SRC)/library_tty_async.js 
 
-library_pthreadfs.js:  $(LIB_WRAPPER) $(LIB_SYS) $(LIB_FS) $(LIB_MEMFS) $(LIB_FSAFS) $(LIB_TTY) 
+library_pthreadfs.js:  $(LIB_WRAPPER) $(LIB_SYS) $(LIB_FS) $(LIB_MEMFS) $(LIB_SFAFS) $(LIB_FSAFS) $(LIB_TTY)
 	rm -f $@
 	cat $^ > ../$@

--- a/pthreadfs/src/pthreadfs.cpp
+++ b/pthreadfs/src/pthreadfs.cpp
@@ -152,7 +152,7 @@ WASI_CAPI_NOARGS_DEF(sync) {
 SYS_CAPI_DEF(open, 5, long path, long flags, ...) {
   
   std::string pathname((char*) path);
-  if (pathname.rfind("/filesystemaccess", 0) == 0 || pathname.rfind("filesystemaccess", 0) == 0) {
+  if (pathname.rfind("/pthreadfs", 0) == 0 || pathname.rfind("pthreadfs", 0) == 0) {
     va_list vl;
     va_start(vl, flags);
     mode_t mode = va_arg(vl, mode_t);
@@ -302,7 +302,7 @@ void emscripten_init_pthreadfs() {
   });
   g_synctoasync_helper.doWork([](SyncToAsync::Callback resume) {
     g_resumeFct = [resume]() { resume(); };
-    init_fsafs(&resumeWrapper_v);
+    init_backend(&resumeWrapper_v);
   });
   return;
 }

--- a/pthreadfs/src/pthreadfs.h
+++ b/pthreadfs/src/pthreadfs.h
@@ -69,7 +69,7 @@
   return __sys_##name(__VA_ARGS__);
 #define SYS_SYNCTOASYNC_PATH(name, ...) \
   std::string pathname((char*) path); \
-  if (pathname.rfind("/filesystemaccess", 0) == 0 || pathname.rfind("filesystemaccess", 0) == 0) { \
+  if (pathname.rfind("/pthreadfs", 0) == 0 || pathname.rfind("pthreadfs", 0) == 0) { \
     g_synctoasync_helper.doWork([__VA_ARGS__](SyncToAsync::Callback resume) { \
       g_resumeFct = [resume]() { resume(); }; \
       __sys_##name##_async(__VA_ARGS__, &resumeWrapper_l); \
@@ -81,8 +81,7 @@
 extern "C" {
   // Helpers
   extern void init_pthreadfs(void (*fun)(void));
-  extern void init_sfafs(void (*fun)(void));
-  extern void init_fsafs(void (*fun)(void));
+  extern void init_backend(void (*fun)(void));
   void emscripten_init_pthreadfs();
 
   // WASI


### PR DESCRIPTION
With this change, PThreads gains support for multiple storage backends, namely OPFS Access Handles, Storage Foundation API and MEMFS.

The initialization code checks which backends are available and picks (in order) from the following list:
1. OPFS Access Handles - see https://github.com/WICG/file-system-access/blob/main/AccessHandle.md
2. Storage Foundation API - https://github.com/WICG/storage-foundation-api-explainer
3. Emscripten's in-Memory file system (MEMFS).