### PR TITLE
Shorter StorageFoundation Encoding

### DIFF
--- a/pthreadfs/README.md
+++ b/pthreadfs/README.md
@@ -74,7 +74,7 @@ See `pthreadfs/examples/emscripten-tests/fsafs.cpp` for exemplary usage.
 - PThreadFS depends on C++ libraries. `EM_PTHREADFS_ASM()` cannot be used within C files.
 - Performance is good if and only if optimizations (compiler option `-O2`) are enabled and DevTools are closed.
 - Accessing the file system before `main()` is called may not work. 
-- The Storage Foundation backend is particularly experimental.
+- The Storage Foundation backend requires case-insensitive file names.
 - Compiling with the Closure Compiler is not supported.
 - Compiling with optimization `-O3` is not yet supported and may lead to a faulty build.
 

--- a/pthreadfs/examples/emscripten-tests/filenames.cpp
+++ b/pthreadfs/examples/emscripten-tests/filenames.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2013 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <assert.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+static void create_file(const char *path, const char *buffer, int mode) {
+  int fd = open(path, O_WRONLY | O_CREAT, mode);
+  assert(fd >= 0);
+
+  int err = write(fd, buffer, sizeof(char) * strlen(buffer));
+  assert(err ==  (sizeof(char) * strlen(buffer)));
+
+  close(fd);
+}
+
+void setup() {
+  int err;
+  err = mkdir("persistent/lowercase", 0777);
+  assert(!err);
+  err = mkdir("persistent/UPPERCASE", 0777);
+  assert(!err);
+  err = mkdir("persistent/mixed_case-folder", 0777);
+  assert(!err);
+  create_file("persistent/lowercase/UPPER.txt", "content UPPER.txt", 0666);
+  create_file("persistent/UPPERCASE/bla.BLA_bla", "content bla.BLA_bla\n", 0666);
+  create_file("persistent/mixed_case-folder/some file .txt", "content some file .txt", 0666);
+}
+
+void cleanup() {
+  unlink("persistent/lowercase/UPPER.txt");
+  unlink("persistent/UPPERCASE/bla.BLA_bla");
+  unlink("persistent/mixed_case-folder/some file .txt");
+  rmdir("persistent/lowercase");
+  rmdir("persistent/UPPERCASE");
+  rmdir("persistent/mixed_case-folder");
+}
+
+void test() {
+  int err;
+  DIR *dir;
+  struct dirent *ent;
+  int i;
+
+  //
+  // do a normal read with readdir
+  //
+  dir = opendir("persistent/lowercase/");
+  assert(dir);
+  int seen[3] = { 0, 0, 0 };
+  for (i = 0; i < 3; i++) {
+    errno = 0;
+    ent = readdir(dir);
+    //printf("ent, errno: %p, %d\n", ent, errno);
+    assert(ent);
+    printf("%d file: %s (%d : %lu)\n", i, ent->d_name, ent->d_reclen, sizeof(*ent));
+    assert(ent->d_reclen == sizeof(*ent));
+    if (!seen[0] && !strcmp(ent->d_name, ".")) {
+      assert(ent->d_type & DT_DIR);
+      seen[0] = 1;
+      continue;
+    }
+    if (!seen[1] && !strcmp(ent->d_name, "..")) {
+      assert(ent->d_type & DT_DIR);
+      seen[1] = 1;
+      continue;
+    }
+    if (!seen[2] && !strcmp(ent->d_name, "upper.txt")) {
+      assert(ent->d_type & DT_REG);
+      seen[2] = 1;
+      continue;
+    }
+    assert(0 && "odd filename");
+  }
+  ent = readdir(dir);
+  if (ent) printf("surprising ent: %p : %s\n", ent, ent->d_name);
+  assert(!ent);
+
+  err = closedir(dir);
+  assert(!err);
+
+  dir = opendir("persistent/UPPERCASE/");
+  assert(dir);
+  int seen_2[3] = { 0, 0, 0 };
+  for (i = 0; i < 3; i++) {
+    errno = 0;
+    ent = readdir(dir);
+    //printf("ent, errno: %p, %d\n", ent, errno);
+    assert(ent);
+    printf("%d file: %s (%d : %lu)\n", i, ent->d_name, ent->d_reclen, sizeof(*ent));
+    assert(ent->d_reclen == sizeof(*ent));
+    if (!seen_2[0] && !strcmp(ent->d_name, ".")) {
+      assert(ent->d_type & DT_DIR);
+      seen_2[0] = 1;
+      continue;
+    }
+    if (!seen_2[1] && !strcmp(ent->d_name, "..")) {
+      assert(ent->d_type & DT_DIR);
+      seen_2[1] = 1;
+      continue;
+    }
+    if (!seen_2[2] && !strcmp(ent->d_name, "bla.bla_bla")) {
+      assert(ent->d_type & DT_REG);
+      seen_2[2] = 1;
+      continue;
+    }
+    assert(0 && "odd filename");
+  }
+  ent = readdir(dir);
+  if (ent) printf("surprising ent: %p : %s\n", ent, ent->d_name);
+  assert(!ent);
+
+  err = closedir(dir);
+  assert(!err);
+
+  dir = opendir("persistent/mixed_case-folder/");
+  assert(dir);
+  int seen_3[3] = { 0, 0, 0 };
+  for (i = 0; i < 3; i++) {
+    errno = 0;
+    ent = readdir(dir);
+    //printf("ent, errno: %p, %d\n", ent, errno);
+    assert(ent);
+    printf("%d file: %s (%d : %lu)\n", i, ent->d_name, ent->d_reclen, sizeof(*ent));
+    assert(ent->d_reclen == sizeof(*ent));
+    if (!seen_3[0] && !strcmp(ent->d_name, ".")) {
+      assert(ent->d_type & DT_DIR);
+      seen_3[0] = 1;
+      continue;
+    }
+    if (!seen_3[1] && !strcmp(ent->d_name, "..")) {
+      assert(ent->d_type & DT_DIR);
+      seen_3[1] = 1;
+      continue;
+    }
+    if (!seen_3[2] && !strcmp(ent->d_name, "some file .txt")) {
+      assert(ent->d_type & DT_REG);
+      seen_3[2] = 1;
+      continue;
+    }
+    assert(0 && "odd filename");
+  }
+  ent = readdir(dir);
+  if (ent) printf("surprising ent: %p : %s\n", ent, ent->d_name);
+  assert(!ent);
+
+  err = closedir(dir);
+  assert(!err);
+
+  int fd = open("persistent/UPPERCASE/bla.BLA_bla", O_RDONLY, 0777);
+  assert(fd >= 0);
+
+  char readbuf[100];
+
+  err = read(fd, readbuf, sizeof(char) * 100);
+  assert(err > 0);
+  printf("%s",readbuf);
+
+  close(fd);
+
+  puts("success");
+}
+
+int main() {
+  setup();
+  test();
+  cleanup();
+  return EXIT_SUCCESS;
+}

--- a/pthreadfs/examples/emscripten-tests/filenames.cpp
+++ b/pthreadfs/examples/emscripten-tests/filenames.cpp
@@ -64,61 +64,61 @@ void test_file_contents(const char* path) {
 
 void test_readdir(const char* path) {
   int err;
-  DIR* dir;
-  struct dirent* ent;
+  DIR* directory_handle;
+  struct dirent* directory_entry;
   int i;
 
-  const char* filename = strrchr(path, '/')+1;
-  char * filename_lowercase = (char *)malloc(strlen(filename) + 1);
+  const char* filename = strrchr(path, '/') + 1;
+  char* filename_lowercase = (char*)malloc(strlen(filename) + 1);
   strcpy(filename_lowercase, filename);
-  for(int i = 0; filename_lowercase[i]; i++){
+  for (int i = 0; filename_lowercase[i]; i++) {
     filename_lowercase[i] = tolower(filename_lowercase[i]);
   }
 
   int length_of_path = filename - path;
-  char *folder = (char *) malloc(length_of_path + 1);
+  char* folder = (char*)malloc(length_of_path + 1);
   memcpy(folder, path, length_of_path);
   folder[length_of_path] = '\0';
 
   printf("Test readdir for path %s\n", path);
   create_file(path, /*buffer=*/path, 0666);
 
-
-  dir = opendir(folder);
-  assert(dir);
-  int seen[3] = {0, 0, 0};
+  directory_handle = opendir(folder);
+  assert(directory_handle);
+  int seen_files[3] = {0, 0, 0};
   for (i = 0; i < 3; i++) {
     errno = 0;
-    ent = readdir(dir);
-    assert(ent);
-    assert(ent->d_reclen == sizeof(*ent));
+    directory_entry = readdir(directory_handle);
+    assert(directory_entry);
+    assert(directory_entry->d_reclen == sizeof(*directory_entry));
     // Convert filenames to lowercase, since the system is supposed to be case-insensitive
-    for(int i = 0; ent->d_name[i]; i++){
-      ent->d_name[i] = tolower(ent->d_name[i]);
+    for (int i = 0; directory_entry->d_name[i]; i++) {
+      directory_entry->d_name[i] = tolower(directory_entry->d_name[i]);
     }
-    if (!seen[0] && !strcmp(ent->d_name, ".")) {
-      assert(ent->d_type & DT_DIR);
-      seen[0] = 1;
+    if (!seen_files[0] && !strcmp(directory_entry->d_name, ".")) {
+      assert(directory_entry->d_type & DT_DIR);
+      seen_files[0] = 1;
       continue;
     }
-    if (!seen[1] && !strcmp(ent->d_name, "..")) {
-      assert(ent->d_type & DT_DIR);
-      seen[1] = 1;
+    if (!seen_files[1] && !strcmp(directory_entry->d_name, "..")) {
+      assert(directory_entry->d_type & DT_DIR);
+      seen_files[1] = 1;
       continue;
     }
-    if (!seen[2] && !strcmp(ent->d_name, filename_lowercase)) {
-      assert(ent->d_type & DT_REG);
-      seen[2] = 1;
+    if (!seen_files[2] && !strcmp(directory_entry->d_name, filename_lowercase)) {
+      assert(directory_entry->d_type & DT_REG);
+      seen_files[2] = 1;
       continue;
     }
-    assert(0 && "odd filename");
+    assert(0 && "Found unexpected file in directory");
   }
-  ent = readdir(dir);
-  if (ent)
-    printf("surprising ent: %p : %s\n", ent, ent->d_name);
-  assert(!ent);
+  directory_entry = readdir(directory_handle);
+  if (directory_entry)
+    printf(
+      "Unexpected path in directory found: %p : %s\n", directory_entry, directory_entry->d_name);
+  assert(!directory_entry);
 
-  err = closedir(dir);
+  err = closedir(directory_handle);
   assert(!err);
 
   unlink(path);
@@ -129,17 +129,17 @@ void test_readdir(const char* path) {
 int main() {
   setup();
 
-  const char* paths[] = {"persistent/filenametest/file.txt", "persistent/filenametest/file with space",
-    "persistent/filenametest/hyphen-file", "persistent/filenametest/underscore_file", "persistent/filenametest/UPPERCASE",
-    "persistent/filenametest/mixedCASE", "persistent/filenametest/file!", "persistent/filenametest/file(parenthesis)",
-    "persistent/filenametest/fileumlautäöüëé", "persistent/folder space/file",
-    "persistent/folder_underscore/file"};
+  const char* paths[] = {"persistent/filenametest/file.txt",
+    "persistent/filenametest/file with space", "persistent/filenametest/hyphen-file",
+    "persistent/filenametest/underscore_file", "persistent/filenametest/UPPERCASE",
+    "persistent/filenametest/mixedCASE", "persistent/filenametest/file!",
+    "persistent/filenametest/file(parenthesis)", "persistent/filenametest/fileumlautäöüëé",
+    "persistent/folder space/file", "persistent/folder_underscore/file"};
 
-  for (size_t i = 0; i < sizeof(paths)/sizeof(paths[0]); i++) {
+  for (size_t i = 0; i < sizeof(paths) / sizeof(paths[0]); i++) {
     test_file_contents(paths[i]);
     test_readdir(paths[i]);
   }
-  // test_preexisting_files();
   cleanup();
 
   puts("success");

--- a/pthreadfs/library_pthreadfs.js
+++ b/pthreadfs/library_pthreadfs.js
@@ -2989,11 +2989,11 @@ mergeInto(LibraryManager.library, {
         node = node.parent;
       }
       if (!parts.length) {
-        return '_';
+        return '/';
       }
       parts.push('');
       parts.reverse();
-      return parts.join('_');
+      return parts.join('/').toLowerCase();
     },
 
     encodedPath: function(node) {
@@ -3001,40 +3001,40 @@ mergeInto(LibraryManager.library, {
     },
 
     joinPaths: function(path1, path2) {
-      if (path1.endsWith('_')) {
-        if (path2.startsWith('_')) {
+      if (path1.endsWith('/')) {
+        if (path2.startsWith('/')) {
           return path1.slice(0, -1) + path2;
         }
         return path1 + path2;
       } else {
-        if (path2.startsWith('_')) {
+        if (path2.startsWith('/')) {
           return path1 + path2;
         }
-        return path1 + '_' + path2;
+        return path1 + '/' + path2;
       }
     },
 
-    // directoryPath ensures path ends with a path delimiter ('_').
+    // directoryPath ensures path ends with a path delimiter ('/').
     //
     // Example:
     // * directoryPath('_dir') = '_dir_'
     // * directoryPath('_dir_') = '_dir_'
     directoryPath: function(path) {
-      if (path.length && path.slice(-1) == '_') {
+      if (path.length && path.slice(-1) == '/') {
         return path;
       }
-      return path + '_';
+      return path + '/';
     },
 
     // extractFilename strips the parent path and drops suffixes after '_'.
     //
     // Example:
-    // * extractFilename('_dir', '_dir_myfile') = 'myfile'
-    // * extractFilename('_dir', '_dir_mydir_myfile') = 'mydir'
+    // * extractFilename('/dir', '/dir/myfile') = 'myfile'
+    // * extractFilename('/dir', '/dir/mydir/myfile') = 'mydir'
     extractFilename: function(parent, path) {
       parent = SFAFS.directoryPath(parent);
       path = path.substr(parent.length);
-      var index = path.indexOf('_');
+      var index = path.indexOf('/');
       if (index == -1) {
         return path;
       }
@@ -3044,20 +3044,51 @@ mergeInto(LibraryManager.library, {
     encodePath: function(path) {
       //TODO: this is a random hex encoding decide and document on reasonable
       //scheme
-      var s = unescape(encodeURIComponent(path))
-      var h = ''
-      for (var i = 0; i < s.length; i++) {
-          h += s.charCodeAt(i).toString(16)
-      }
-      return h
+      // var s = unescape(encodeURIComponent(path))
+      // var h = ''
+      // for (var i = 0; i < s.length; i++) {
+      //     h += s.charCodeAt(i).toString(16)
+      // }
+      // return h
+      let uri_encoded_string = encodeURIComponent(path);
+      // encodeURIComponent leaves the following non-alphanumeric chars: - _ . ! ~ * ' ( )
+      // Those are encoded similar to percent encoding:
+      let encoded_path_with_percent = uri_encoded_string.replaceAll('-', '%2d');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('_', '%5f');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('.', '%2e');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('!', '%21');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('~', '%7e');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('*', '%2a');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll("'", '%27');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll("(", '%28');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll(")", '%29');
+
+      let encoded_path = encoded_path_with_percent.replaceAll('%', '_');
+      encoded_path = encoded_path.toLowerCase();
+      return encoded_path;
     },
 
     decodePath: function(hex) {
-      var s = ''
-      for (var i = 0; i < hex.length; i+=2) {
-          s += String.fromCharCode(parseInt(hex.substr(i, 2), 16))
-      }
-      return decodeURIComponent(escape(s))
+      // let decoded_path = hex.replaceAll('_____').
+      // var s = ''
+      // for (var i = 0; i < hex.length; i+=2) {
+      //     s += String.fromCharCode(parseInt(hex.substr(i, 2), 16))
+      // }
+      // return decodeURIComponent(escape(s))
+      let encoded_path_with_percent = hex.replaceAll('_', '%');
+
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%2d', '-');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%5f', '_');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%2e', '.');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%21', '!');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%7e', '~');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%2a', '*');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%27', "'");
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%28', "(");
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%29', ")");
+
+      let decoded_path = decodeURIComponent(encoded_path_with_percent);
+      return decoded_path;
     },
 
 

--- a/pthreadfs/src/js/library_sfafs_async.js
+++ b/pthreadfs/src/js/library_sfafs_async.js
@@ -286,17 +286,19 @@ mergeInto(LibraryManager.library, {
 
         let children = encoded_children.map((child) => SFAFS.decodePath(child));
 
+        let lowercase_name = name.toLowerCase()
+
         var exists = false;
         var mode = 511 /* 0777 */
         for (var i = 0; i < children.length; ++i) {
           var path = children[i].substr(parentPath.length);
-          if (path == name) {
+          if (path == lowercase_name) {
             exists = true;
             mode |= {{{ cDefine('S_IFREG') }}};
             break;
           }
 
-         let subdirName = SFAFS.directoryPath(name);
+         let subdirName = SFAFS.directoryPath(lowercase_name);
           if (path.startsWith(subdirName)) {
             exists = true;
             mode |= {{{ cDefine('S_IFDIR') }}};
@@ -308,7 +310,7 @@ mergeInto(LibraryManager.library, {
           throw PThreadFS.genericErrors[{{{ cDefine('ENOENT') }}}];
         }
 
-        var node = PThreadFS.createNode(parent, name, mode);
+        var node = PThreadFS.createNode(parent, lowercase_name, mode);
         node.node_ops = SFAFS.node_ops;
         node.stream_ops = SFAFS.stream_ops;
         return node;

--- a/pthreadfs/src/js/library_sfafs_async.js
+++ b/pthreadfs/src/js/library_sfafs_async.js
@@ -38,11 +38,11 @@ mergeInto(LibraryManager.library, {
         node = node.parent;
       }
       if (!parts.length) {
-        return '_';
+        return '/';
       }
       parts.push('');
       parts.reverse();
-      return parts.join('_');
+      return parts.join('/').toLowerCase();
     },
 
     encodedPath: function(node) {
@@ -50,40 +50,40 @@ mergeInto(LibraryManager.library, {
     },
 
     joinPaths: function(path1, path2) {
-      if (path1.endsWith('_')) {
-        if (path2.startsWith('_')) {
+      if (path1.endsWith('/')) {
+        if (path2.startsWith('/')) {
           return path1.slice(0, -1) + path2;
         }
         return path1 + path2;
       } else {
-        if (path2.startsWith('_')) {
+        if (path2.startsWith('/')) {
           return path1 + path2;
         }
-        return path1 + '_' + path2;
+        return path1 + '/' + path2;
       }
     },
 
-    // directoryPath ensures path ends with a path delimiter ('_').
+    // directoryPath ensures path ends with a path delimiter ('/').
     //
     // Example:
     // * directoryPath('_dir') = '_dir_'
     // * directoryPath('_dir_') = '_dir_'
     directoryPath: function(path) {
-      if (path.length && path.slice(-1) == '_') {
+      if (path.length && path.slice(-1) == '/') {
         return path;
       }
-      return path + '_';
+      return path + '/';
     },
 
     // extractFilename strips the parent path and drops suffixes after '_'.
     //
     // Example:
-    // * extractFilename('_dir', '_dir_myfile') = 'myfile'
-    // * extractFilename('_dir', '_dir_mydir_myfile') = 'mydir'
+    // * extractFilename('/dir', '/dir/myfile') = 'myfile'
+    // * extractFilename('/dir', '/dir/mydir/myfile') = 'mydir'
     extractFilename: function(parent, path) {
       parent = SFAFS.directoryPath(parent);
       path = path.substr(parent.length);
-      var index = path.indexOf('_');
+      var index = path.indexOf('/');
       if (index == -1) {
         return path;
       }
@@ -93,20 +93,51 @@ mergeInto(LibraryManager.library, {
     encodePath: function(path) {
       //TODO: this is a random hex encoding decide and document on reasonable
       //scheme
-      var s = unescape(encodeURIComponent(path))
-      var h = ''
-      for (var i = 0; i < s.length; i++) {
-          h += s.charCodeAt(i).toString(16)
-      }
-      return h
+      // var s = unescape(encodeURIComponent(path))
+      // var h = ''
+      // for (var i = 0; i < s.length; i++) {
+      //     h += s.charCodeAt(i).toString(16)
+      // }
+      // return h
+      let uri_encoded_string = encodeURIComponent(path);
+      // encodeURIComponent leaves the following non-alphanumeric chars: - _ . ! ~ * ' ( )
+      // Those are encoded similar to percent encoding:
+      let encoded_path_with_percent = uri_encoded_string.replaceAll('-', '%2d');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('_', '%5f');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('.', '%2e');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('!', '%21');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('~', '%7e');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('*', '%2a');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll("'", '%27');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll("(", '%28');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll(")", '%29');
+
+      let encoded_path = encoded_path_with_percent.replaceAll('%', '_');
+      encoded_path = encoded_path.toLowerCase();
+      return encoded_path;
     },
 
     decodePath: function(hex) {
-      var s = ''
-      for (var i = 0; i < hex.length; i+=2) {
-          s += String.fromCharCode(parseInt(hex.substr(i, 2), 16))
-      }
-      return decodeURIComponent(escape(s))
+      // let decoded_path = hex.replaceAll('_____').
+      // var s = ''
+      // for (var i = 0; i < hex.length; i+=2) {
+      //     s += String.fromCharCode(parseInt(hex.substr(i, 2), 16))
+      // }
+      // return decodeURIComponent(escape(s))
+      let encoded_path_with_percent = hex.replaceAll('_', '%');
+
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%2d', '-');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%5f', '_');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%2e', '.');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%21', '!');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%7e', '~');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%2a', '*');
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%27', "'");
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%28', "(");
+      encoded_path_with_percent = encoded_path_with_percent.replaceAll('%29', ")");
+
+      let decoded_path = decodeURIComponent(encoded_path_with_percent);
+      return decoded_path;
     },
 
 

--- a/pthreadfs/src/js/library_sfafs_async.js
+++ b/pthreadfs/src/js/library_sfafs_async.js
@@ -66,8 +66,8 @@ mergeInto(LibraryManager.library, {
     // directoryPath ensures path ends with a path delimiter ('/').
     //
     // Example:
-    // * directoryPath('_dir') = '_dir_'
-    // * directoryPath('_dir_') = '_dir_'
+    // * directoryPath('/dir') = '/dir/'
+    // * directoryPath('/dir/') = '/dir/'
     directoryPath: function(path) {
       if (path.length && path.slice(-1) == '/') {
         return path;
@@ -75,7 +75,7 @@ mergeInto(LibraryManager.library, {
       return path + '/';
     },
 
-    // extractFilename strips the parent path and drops suffixes after '_'.
+    // extractFilename strips the parent path and drops suffixes after '/'.
     //
     // Example:
     // * extractFilename('/dir', '/dir/myfile') = 'myfile'
@@ -90,18 +90,27 @@ mergeInto(LibraryManager.library, {
       return path.substr(0, index);
     },
 
+    /* Path encoding for Storage Foundation API
+     * 
+     * Storage Foundation does not support directories, hence SFAFS encodes a
+     * file's full path in the file name. Storage Foundation imposes the
+     * following restrictions on file names:
+     * - A name can be at most 100 characters long, and
+     * - Only characters a-z, 0-9 and _ may be used.
+     * 
+     * SFAFS therefore uses an adapted, case-insensitive, case-preserving
+     * Percent-encoding for encoding file names. Since % itself is an
+     * unsupported character for Storage Foundation, it is replaced with _
+     * (underscore). Using a case-insensitive encoding significantly saves
+     * encoding length and therefore allows SFAFS to support paths up to ~90
+     * characters.
+    */
     encodePath: function(path) {
-      //TODO: this is a random hex encoding decide and document on reasonable
-      //scheme
-      // var s = unescape(encodeURIComponent(path))
-      // var h = ''
-      // for (var i = 0; i < s.length; i++) {
-      //     h += s.charCodeAt(i).toString(16)
-      // }
-      // return h
       let uri_encoded_string = encodeURIComponent(path);
-      // encodeURIComponent leaves the following non-alphanumeric chars: - _ . ! ~ * ' ( )
-      // Those are encoded similar to percent encoding:
+      // encodeURIComponent leaves the following non-alphanumeric chars: 
+      // - _ . ! ~ * ' ( )
+      // Those are replaced (similar to percent encoding) with their byte value
+      // in ASCII as a hex, preceded by %.
       let encoded_path_with_percent = uri_encoded_string.replaceAll('-', '%2d');
       encoded_path_with_percent = encoded_path_with_percent.replaceAll('_', '%5f');
       encoded_path_with_percent = encoded_path_with_percent.replaceAll('.', '%2e');
@@ -117,14 +126,8 @@ mergeInto(LibraryManager.library, {
       return encoded_path;
     },
 
-    decodePath: function(hex) {
-      // let decoded_path = hex.replaceAll('_____').
-      // var s = ''
-      // for (var i = 0; i < hex.length; i+=2) {
-      //     s += String.fromCharCode(parseInt(hex.substr(i, 2), 16))
-      // }
-      // return decodeURIComponent(escape(s))
-      let encoded_path_with_percent = hex.replaceAll('_', '%');
+    decodePath: function(encoded_path) {
+      let encoded_path_with_percent = encoded_path.replaceAll('_', '%');
 
       encoded_path_with_percent = encoded_path_with_percent.replaceAll('%2d', '-');
       encoded_path_with_percent = encoded_path_with_percent.replaceAll('%5f', '_');


### PR DESCRIPTION
This PR switches the Storage Foundation backend to a more space-efficient encoding of file paths. This allows the SF backend to support longer file paths.

Storage Foundation does not support folders and filenames must come from the limited character set a-zA-Z0-9_ . The SF backend uses a file's full path as the file's name. In order to account for the limited character set, the file name must be encoded.

The new encoding uses a modified [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding): In addition to the normal percent encoding, the remaining unsupported characters percent-encoded, and all % signs are converted to _. In order to further shorten the encoding, the backend is converted to be **case-insensitive**, while other backends remain case-sensitive for the time being.