### PR TITLE
Add improved file packaging support

### DIFF
--- a/pthreadfs/examples/Makefile
+++ b/pthreadfs/examples/Makefile
@@ -1,19 +1,21 @@
 # Emscripten
 EMCC = emcc
-FILE_PACKAGER = ../../tools/file_packager.py
+FILE_PACKAGER = ../file_packager.py
 
 # Define some folders
 EMTESTS = emscripten-tests
 NODEJSTESTS = nodejs-tests
 SQLITETESTS = sqlite-speedtest
-PRELOADTESTS = preload-tests
+PACKAGERTESTS = packager-tests
 OBJ = out/bc
 
 PTHREADFS_JS = ../library_pthreadfs.js
 PTHREADFS_H = ../pthreadfs.h
 PTHREADFS_CPP = ../pthreadfs.cpp
 
-PRELOADFILES = $(PRELOADTESTS)/input/smallfile.txt $(PRELOADTESTS)/input/subfolder/mediumfile.txt $(PRELOADTESTS)/input/bigfile.txt
+PACKAGER_INPUT_SMALL = $(PACKAGERTESTS)/input/small/smallfile.txt
+PACKAGER_INPUT_MEDIUMLARGE = $(PACKAGERTESTS)/input/mediumlarge/subfolder/mediumfile.txt $(PACKAGERTESTS)/input/mediumlarge/bigfile.txt
+PACKAGER_INPUT = $(PACKAGER_INPUT_SMALL) $(PACKAGER_INPUT_MEDIUMLARGE)
 
 # I got this handy makefile syntax from : https://github.com/mandel59/sqlite-wasm (MIT License) Credited in LICENSE
 # To use another version of Sqlite, visit https://www.sqlite.org/download.html and copy the appropriate values here:
@@ -26,7 +28,7 @@ SQLITE_SPEEDTEST_URL = https://sqlite.org/src/raw/5e5b805f24cc939656058f6a498f5a
 SQLITE_SPEEDTEST_SHA1 = f0edde2ad68f090e4676ac30042e0f6b765a8528
 
 .PHONY: all 
-all: sqlite-speedtest emscripten-tests preload-tests
+all: sqlite-speedtest emscripten-tests packager-tests
 
 ## cache
 cache/$(SQLITE_AMALGAMATION).zip:
@@ -114,7 +116,7 @@ $(OBJ)/%.o : $(EMTESTS)/%.cpp
 	mkdir -p $(OBJ)
 	$(EMCC) -c $(CFLAGS) $< -o $@
 
-$(OBJ)/%.o : $(PRELOADTESTS)/%.cpp
+$(OBJ)/%.o : $(PACKAGERTESTS)/%.cpp
 	mkdir -p $(OBJ)
 	$(EMCC) -c $(CFLAGS) $< -o $@
 
@@ -144,25 +146,37 @@ dist/$(NODEJSTESTS)/%.js : $(OBJ)/%.o $(OBJ)/pthreadfs.o $(PTHREADFS_JS)
 	$(EMCC) $(LINK_FLAGS) --js-library=$(PTHREADFS_JS) $< $(word 2,$^) -o $@
 	
 
-# Compiling the preload-tests requires manual creation of the following files
-# - $(PRELOADTESTS)/input/smallfile.txt: Size 188 bytes, first line "These are the contents of a very small file."
-# - $(PRELOADTESTS)/input/subfolder/mediumfile.txt: Size 138670 bytes, first line "Begin mediumfile.txt -------------------------------------------"
-# - $(PRELOADTESTS)/input/bigfile.txt: Size 212992000 bytes, first line "Begin bigfile.txt ----------------------------------------------"
-.PHONY: preload-tests
-preload-tests: dist/$(PRELOADTESTS)/no_pthreadfs.html dist/$(PRELOADTESTS)/preload_pthreadfs.html dist/$(PRELOADTESTS)/node_preload_pthreadfs.js
+# Compiling the packager tests requires manual creation of the following files
+# - $(PACKAGERTESTS)/input/small/smallfile.txt: Size 188 bytes, first line "These are the contents of a very small file."
+# - $(PACKAGERTESTS)/input/mediumlarge/subfolder/mediumfile.txt: Size 138670 bytes, first line "Begin mediumfile.txt -------------------------------------------"
+# - $(PACKAGERTESTS)/input/mediumlarge/bigfile.txt: Size 212992000 bytes, first line "Begin bigfile.txt ----------------------------------------------"
+.PHONY: packager-tests
+packager-tests: dist/$(PACKAGERTESTS)/preloading_without_pthreadfs.html dist/$(PACKAGERTESTS)/preloading.html dist/$(PACKAGERTESTS)/intermediate_loading.html
 
-dist/$(PRELOADTESTS)/preload_filepackage.js: $(PRELOADFILES) $(FILE_PACKAGER)
-	mkdir -p dist/preload-tests/
-	python3 $(FILE_PACKAGER) $(addsuffix .data, $(basename $@)) --preload ./$(PRELOADTESTS)/input@/persistent --use_pthreadfs --js-output=$@
+# Create the file packages
+dist/$(PACKAGERTESTS)/pkg_preload_small.js: $(PACKAGER_INPUT_SMALL) $(FILE_PACKAGER)
+	mkdir -p dist/$(PACKAGERTESTS)/
+	python3 $(FILE_PACKAGER) $(addsuffix .data, $(basename $@)) --preload ./$(PACKAGERTESTS)/input/small@/persistent --use_pthreadfs --js-output=$@
+dist/$(PACKAGERTESTS)/pkg_preload_mediumlarge.js: $(PACKAGER_INPUT_MEDIUMLARGE) $(FILE_PACKAGER)
+	mkdir -p dist/$(PACKAGERTESTS)/
+	python3 $(FILE_PACKAGER) $(addsuffix .data, $(basename $@)) --preload ./$(PACKAGERTESTS)/input/mediumlarge@/persistent --use_pthreadfs --js-output=$@
 
-dist/$(PRELOADTESTS)/preload_pthreadfs.html: $(OBJ)/preload.o $(OBJ)/pthreadfs.o dist/$(PRELOADTESTS)/preload_filepackage.js $(PTHREADFS_JS)
-	mkdir -p dist/preload-tests
-	$(EMCC) $(LINK_FLAGS) -o $@ --js-library=$(PTHREADFS_JS)  --pre-js $(word 3,$^)  $< $(word 2,$^) 
+dist/$(PACKAGERTESTS)/pkg_intermediate_small.js: $(PACKAGER_INPUT_SMALL) $(FILE_PACKAGER)
+	mkdir -p dist/$(PACKAGERTESTS)/
+	python3 $(FILE_PACKAGER) $(addsuffix .data, $(basename $@)) --preload ./$(PACKAGERTESTS)/input/small@/persistent/intermediate_loading --use_pthreadfs --js-output=$@
+dist/$(PACKAGERTESTS)/pkg_intermediate_mediumlarge.js: $(PACKAGER_INPUT_MEDIUMLARGE) $(FILE_PACKAGER)
+	mkdir -p dist/$(PACKAGERTESTS)/
+	python3 $(FILE_PACKAGER) $(addsuffix .data, $(basename $@)) --preload ./$(PACKAGERTESTS)/input/mediumlarge@/persistent/intermediate_loading --use_pthreadfs --js-output=$@
+
 	
-dist/$(PRELOADTESTS)/no_pthreadfs.html: $(OBJ)/preload.o $(PRELOADFILES)
-	mkdir -p dist/preload-tests
-	$(EMCC) $(LINK_FLAGS) -o $@ --preload-file $(PRELOADTESTS)/input@/persistent $<
+dist/$(PACKAGERTESTS)/preloading_without_pthreadfs.html: $(OBJ)/preloading.o $(PACKAGER_INPUT)
+	mkdir -p dist/$(PACKAGERTESTS)
+	$(EMCC) $(LINK_FLAGS) -o $@ --preload-file $(PACKAGERTESTS)/input/small@/persistent --preload-file $(PACKAGERTESTS)/input/mediumlarge@/persistent $<
 
-dist/$(PRELOADTESTS)/node_preload_pthreadfs.js: $(OBJ)/preload.o $(OBJ)/pthreadfs.o dist/$(PRELOADTESTS)/preload_filepackage.js $(PTHREADFS_JS)
-	mkdir -p dist/preload-tests
-	$(EMCC) $(LINK_FLAGS) -o $@ --js-library=$(PTHREADFS_JS)  --pre-js $(word 3,$^)  $< $(word 2,$^) 
+dist/$(PACKAGERTESTS)/preloading.html: $(OBJ)/preloading.o $(OBJ)/pthreadfs.o dist/$(PACKAGERTESTS)/pkg_preload_small.js dist/$(PACKAGERTESTS)/pkg_preload_mediumlarge.js $(PTHREADFS_JS)
+	mkdir -p dist/$(PACKAGERTESTS)
+	$(EMCC) $(LINK_FLAGS) -o $@ --js-library=$(PTHREADFS_JS)  --pre-js $(word 3,$^) --pre-js $(word 4,$^)  $< $(word 2,$^) 
+
+dist/$(PACKAGERTESTS)/intermediate_loading.html: $(OBJ)/intermediate_loading.o $(OBJ)/pthreadfs.o dist/$(PACKAGERTESTS)/pkg_intermediate_small.js dist/$(PACKAGERTESTS)/pkg_intermediate_mediumlarge.js $(PTHREADFS_JS)
+	mkdir -p dist/$(PACKAGERTESTS)
+	$(EMCC) $(LINK_FLAGS) -o $@ --js-library=$(PTHREADFS_JS) $< $(word 2,$^)

--- a/pthreadfs/examples/packager-tests/intermediate_loading.cpp
+++ b/pthreadfs/examples/packager-tests/intermediate_loading.cpp
@@ -7,11 +7,11 @@
 
 
 #include <assert.h>
-#include <emscripten.h>
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <sys/stat.h>
+#include "pthreadfs.h"
 
 int test(std::string file_path, std::string first_line, int size) {
   std::cout << "Start reading first line of file " << file_path << std::endl;
@@ -32,12 +32,15 @@ int test(std::string file_path, std::string first_line, int size) {
 }
 
 int main() {
-  std::cout << "Start preload test.\n";
+  std::cout << "Do some work before loading files.\n";
 
-  test("persistent/smallfile.txt", "These are the contents of a very small file.", 188);
-  test("persistent/subfolder/mediumfile.txt",
+  pthreadfs_load_package("pkg_intermediate_small.js");
+  test("persistent/intermediate_loading/smallfile.txt", "These are the contents of a very small file.", 188);
+
+  pthreadfs_load_package("pkg_intermediate_mediumlarge.js");
+  test("persistent/intermediate_loading/subfolder/mediumfile.txt",
     "Begin mediumfile.txt -------------------------------------------", 138670);
-  test("persistent/bigfile.txt", "Begin bigfile.txt ----------------------------------------------",
+  test("persistent/intermediate_loading/bigfile.txt", "Begin bigfile.txt ----------------------------------------------",
     212992000);
 
   std::cout << "Success.\n";

--- a/pthreadfs/examples/packager-tests/preloading.cpp
+++ b/pthreadfs/examples/packager-tests/preloading.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+
+#include <assert.h>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <sys/stat.h>
+
+int test(std::string file_path, std::string first_line, int size) {
+  std::cout << "Start reading first line of file " << file_path << std::endl;
+  std::ifstream stream(file_path);
+  std::string read_line;
+  std::getline(stream, read_line);
+  stream.close();
+
+  std::cout << "  " << read_line << std::endl;
+  assert(read_line == first_line);
+
+  struct stat s;
+  int err = stat(file_path.c_str(), &s);
+  assert(!err);
+  assert(s.st_size == size);
+  
+  return 0;
+}
+
+int main() {
+  std::cout << "Test preloading files.\n";
+
+  test("persistent/smallfile.txt", "These are the contents of a very small file.", 188);
+  test("persistent/subfolder/mediumfile.txt",
+    "Begin mediumfile.txt -------------------------------------------", 138670);
+  test("persistent/bigfile.txt", "Begin bigfile.txt ----------------------------------------------",
+    212992000);
+
+  std::cout << "Success.\n";
+  return 0;
+}

--- a/pthreadfs/file_packager.py
+++ b/pthreadfs/file_packager.py
@@ -271,7 +271,7 @@ def main():
        'cannot separate-metadata without both --preloaded files '
        'and a specified --js-output')
 
-  if not from_emcc:
+  if not from_emcc and not use_pthreadfs:
     print('Remember to build the main file with  -s FORCE_FILESYSTEM=1  '
           'so that it includes support for loading this file package',
           file=sys.stderr)
@@ -311,7 +311,8 @@ def main():
   '''
   else:
     ret += '''
-let pthreadfs_preload =
+    (function() {
+let loading_script =
   async function() {
   var loadPackage = async function(metadata) {
   '''
@@ -1109,9 +1110,11 @@ let pthreadfs_preload =
     ret += '''%s
     }
 
-      if (!("pthreadfs_preload" in Module)) {
-        Module["pthreadfs_preload"] = pthreadfs_preload;
+      if (!("pthreadfs_available_packages" in Module)) {
+        Module["pthreadfs_available_packages"] = [];
       }
+      Module["pthreadfs_available_packages"].push(loading_script);
+    })();
     ''' % _metadata_template
 
   if force or len(data_files):

--- a/pthreadfs/library_pthreadfs.js
+++ b/pthreadfs/library_pthreadfs.js
@@ -81,8 +81,8 @@ for (x of SyscallsFunctions) {
   createSyscallWrapper(x.name, x.args, SyscallWrappers);
 }
 
-SyscallWrappers['init_pthreadfs'] = function (folder_ref, resume) {
-
+SyscallWrappers['pthreadfs_init'] =
+  function(folder_ref, resume) {
   let folder = UTF8ToString(folder_ref)
 
   if (typeof folder !== 'string' || folder.includes('/')) {
@@ -97,17 +97,18 @@ SyscallWrappers['init_pthreadfs'] = function (folder_ref, resume) {
     const root = await navigator.storage.getDirectory();
     const present = FileSystemFileHandle.prototype.createSyncAccessHandle !== undefined;
     return present;
-  }
+  };
 
-let storage_foundation_detection = function() {
-  if (typeof storageFoundation == typeof undefined) {
-    return false;
-  }
-  if (storageFoundation.requestCapacitySync(1) === 0) {
-    return false;
-  }
-  return true;
-}
+  let storage_foundation_detection = function() {
+    if (typeof storageFoundation == typeof undefined) {
+      return false;
+    }
+    if (storageFoundation.requestCapacitySync(1) === 0) {
+      return false;
+    }
+    return true;
+  };
+  
   var FSNode = /** @constructor */ function(parent, name, mode, rdev) {
     if (!parent) {
       parent = this;  // root node sets parent to itself
@@ -154,7 +155,7 @@ let storage_foundation_detection = function() {
   });
   PThreadFS.FSNode = FSNode;
 
-  PThreadFS.staticInit().then(async ()=> {
+  PThreadFS.staticInit().then(async () => {
     PThreadFS.ignorePermissions = false;
     let folderpath = '/' + folder;
     await PThreadFS.mkdir(folderpath);
@@ -162,24 +163,21 @@ let storage_foundation_detection = function() {
     let has_storage_foundation = storage_foundation_detection();
 
     if (has_access_handles) {
-      await PThreadFS.mount(FSAFS, { root: '.' }, folderpath);
+      await PThreadFS.mount(FSAFS, {root : '.'}, folderpath);
       console.log('Initialized PThreadFS with OPFS Access Handles');
-    }
-    else if (has_storage_foundation) {
-      await PThreadFS.mount(SFAFS, { root: '.' }, folderpath);
+    } else if (has_storage_foundation) {
+      await PThreadFS.mount(SFAFS, {root : '.'}, folderpath);
   
       // Storage Foundation requires explicit capacity allocations.
       if (storageFoundation.requestCapacity) {
-        await storageFoundation.requestCapacity(1024*1024*1024);
+        await storageFoundation.requestCapacity(1024 * 1024 * 1024);
       }
       console.log('Initialized PThreadFS with Storage Foundation API');
-    }
-    else {
+    } else {
       console.log('Initialized PThreadFS with MEMFS');
     }
-    if ("pthreadfs_preload" in Module) {
-      await Module["pthreadfs_preload"]();
-    }
+    // Load any data added during --pre-js.
+    await PThreadFS.loadAvailablePackages()
     wasmTable.get(resume)();
   });
 }
@@ -2398,6 +2396,15 @@ mergeInto(LibraryManager.library, SyscallsLibrary);
         'MEMFS_ASYNC': MEMFS_ASYNC,
       };
     },
+    // Load all available data packages into the PThreadFS file system.
+    loadAvailablePackages: async function () {
+      if ("pthreadfs_available_packages" in Module) {
+        while (Module["pthreadfs_available_packages"].length > 0) {
+          let package = Module["pthreadfs_available_packages"].pop();
+          await package();
+        }
+      }
+    },
 
     //
     // old v1 compatibility functions
@@ -3049,11 +3056,12 @@ mergeInto(LibraryManager.library, {
      * - A name can be at most 100 characters long, and
      * - Only characters a-z, 0-9 and _ may be used.
      * 
-     * SFAFS therefore uses an adapted, case-insensitive Percent-encoding for
-     * encoding file names. Since % itself is an unsupported character for
-     * Storage Foundation, it is replaced with _ (underscore).
-     * Using a case-insensitive encoding significantly saves encoding length
-     * and therefore allows SFAFS to support paths up to ~90 characters.
+     * SFAFS therefore uses an adapted, case-insensitive, case-preserving
+     * Percent-encoding for encoding file names. Since % itself is an
+     * unsupported character for Storage Foundation, it is replaced with _
+     * (underscore). Using a case-insensitive encoding significantly saves
+     * encoding length and therefore allows SFAFS to support paths up to ~90
+     * characters.
     */
     encodePath: function(path) {
       let uri_encoded_string = encodeURIComponent(path);

--- a/pthreadfs/pthreadfs.h
+++ b/pthreadfs/pthreadfs.h
@@ -103,7 +103,8 @@
 
 extern "C" {
 // Helpers
-extern void init_pthreadfs(const char* folder, void (*fun)(void));
+extern void pthreadfs_init(const char* folder, void (*fun)(void));
+void pthreadfs_load_package(const char* path_to_package);
 void emscripten_init_pthreadfs();
 
 // WASI

--- a/pthreadfs/src/js/library_asyncfs.js
+++ b/pthreadfs/src/js/library_asyncfs.js
@@ -1391,6 +1391,15 @@
         'MEMFS_ASYNC': MEMFS_ASYNC,
       };
     },
+    // Load all available data packages into the PThreadFS file system.
+    loadAvailablePackages: async function () {
+      if ("pthreadfs_available_packages" in Module) {
+        while (Module["pthreadfs_available_packages"].length > 0) {
+          let package = Module["pthreadfs_available_packages"].pop();
+          await package();
+        }
+      }
+    },
 
     //
     // old v1 compatibility functions

--- a/pthreadfs/src/js/pthreadfs.js
+++ b/pthreadfs/src/js/pthreadfs.js
@@ -81,8 +81,8 @@ for (x of SyscallsFunctions) {
   createSyscallWrapper(x.name, x.args, SyscallWrappers);
 }
 
-SyscallWrappers['init_pthreadfs'] = function (folder_ref, resume) {
-
+SyscallWrappers['pthreadfs_init'] =
+  function(folder_ref, resume) {
   let folder = UTF8ToString(folder_ref)
 
   if (typeof folder !== 'string' || folder.includes('/')) {
@@ -97,17 +97,18 @@ SyscallWrappers['init_pthreadfs'] = function (folder_ref, resume) {
     const root = await navigator.storage.getDirectory();
     const present = FileSystemFileHandle.prototype.createSyncAccessHandle !== undefined;
     return present;
-  }
+  };
 
-let storage_foundation_detection = function() {
-  if (typeof storageFoundation == typeof undefined) {
-    return false;
-  }
-  if (storageFoundation.requestCapacitySync(1) === 0) {
-    return false;
-  }
-  return true;
-}
+  let storage_foundation_detection = function() {
+    if (typeof storageFoundation == typeof undefined) {
+      return false;
+    }
+    if (storageFoundation.requestCapacitySync(1) === 0) {
+      return false;
+    }
+    return true;
+  };
+  
   var FSNode = /** @constructor */ function(parent, name, mode, rdev) {
     if (!parent) {
       parent = this;  // root node sets parent to itself
@@ -154,7 +155,7 @@ let storage_foundation_detection = function() {
   });
   PThreadFS.FSNode = FSNode;
 
-  PThreadFS.staticInit().then(async ()=> {
+  PThreadFS.staticInit().then(async () => {
     PThreadFS.ignorePermissions = false;
     let folderpath = '/' + folder;
     await PThreadFS.mkdir(folderpath);
@@ -162,24 +163,21 @@ let storage_foundation_detection = function() {
     let has_storage_foundation = storage_foundation_detection();
 
     if (has_access_handles) {
-      await PThreadFS.mount(FSAFS, { root: '.' }, folderpath);
+      await PThreadFS.mount(FSAFS, {root : '.'}, folderpath);
       console.log('Initialized PThreadFS with OPFS Access Handles');
-    }
-    else if (has_storage_foundation) {
-      await PThreadFS.mount(SFAFS, { root: '.' }, folderpath);
+    } else if (has_storage_foundation) {
+      await PThreadFS.mount(SFAFS, {root : '.'}, folderpath);
   
       // Storage Foundation requires explicit capacity allocations.
       if (storageFoundation.requestCapacity) {
-        await storageFoundation.requestCapacity(1024*1024*1024);
+        await storageFoundation.requestCapacity(1024 * 1024 * 1024);
       }
       console.log('Initialized PThreadFS with Storage Foundation API');
-    }
-    else {
+    } else {
       console.log('Initialized PThreadFS with MEMFS');
     }
-    if ("pthreadfs_preload" in Module) {
-      await Module["pthreadfs_preload"]();
-    }
+    // Load any data added during --pre-js.
+    await PThreadFS.loadAvailablePackages()
     wasmTable.get(resume)();
   });
 }

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -271,7 +271,7 @@ def main():
        'cannot separate-metadata without both --preloaded files '
        'and a specified --js-output')
 
-  if not from_emcc:
+  if not from_emcc and not use_pthreadfs:
     print('Remember to build the main file with  -s FORCE_FILESYSTEM=1  '
           'so that it includes support for loading this file package',
           file=sys.stderr)
@@ -311,7 +311,8 @@ def main():
   '''
   else:
     ret += '''
-let pthreadfs_preload =
+    (function() {
+let loading_script =
   async function() {
   var loadPackage = async function(metadata) {
   '''
@@ -1109,9 +1110,11 @@ let pthreadfs_preload =
     ret += '''%s
     }
 
-      if (!("pthreadfs_preload" in Module)) {
-        Module["pthreadfs_preload"] = pthreadfs_preload;
+      if (!("pthreadfs_available_packages" in Module)) {
+        Module["pthreadfs_available_packages"] = [];
       }
+      Module["pthreadfs_available_packages"].push(loading_script);
+    })();
     ''' % _metadata_template
 
   if force or len(data_files):


### PR DESCRIPTION
This PR adds improved file packaging support.

- It is now possible to add add multiple packages during pre-js for preloading.
- Packaged files can be loaded after the application has started by calling `pthreadfs_load_package(<PACKAGE.js>);` from C++. This function is defined in `pthreadfs.h` and may be exported in order to call it from Javascript.

Tests for the new functionality are available in `pthreadfs/examples/packager-tests/`. Running these tests requires manual creation of the preloaded files, see `pthreadfs/examples/Makefile` for details.