### PR TITLE
Cleaned SQLite test code

### DIFF
--- a/pthreadfs/examples/Makefile
+++ b/pthreadfs/examples/Makefile
@@ -5,7 +5,6 @@ FILE_PACKAGER = ../file_packager.py
 # Define some folders
 EMTESTS = emscripten-tests
 NODEJSTESTS = nodejs-tests
-SQLITETESTS = sqlite-speedtest
 PACKAGERTESTS = packager-tests
 OBJ = out/bc
 
@@ -17,50 +16,13 @@ PACKAGER_INPUT_SMALL = $(PACKAGERTESTS)/input/small/smallfile.txt
 PACKAGER_INPUT_MEDIUMLARGE = $(PACKAGERTESTS)/input/mediumlarge/subfolder/mediumfile.txt $(PACKAGERTESTS)/input/mediumlarge/bigfile.txt
 PACKAGER_INPUT = $(PACKAGER_INPUT_SMALL) $(PACKAGER_INPUT_MEDIUMLARGE)
 
-# I got this handy makefile syntax from : https://github.com/mandel59/sqlite-wasm (MIT License) Credited in LICENSE
-# To use another version of Sqlite, visit https://www.sqlite.org/download.html and copy the appropriate values here:
-SQLITE_AMALGAMATION = sqlite-amalgamation-3350000
-SQLITE_AMALGAMATION_ZIP_URL = https://www.sqlite.org/2021/sqlite-amalgamation-3350000.zip
-SQLITE_AMALGAMATION_ZIP_SHA1 = ba64bad885c9f51df765a9624700747e7bf21b79
-SQLITE_H = sqlite3.h
-SQLITE_SPEEDTEST = speedtest1.c
-SQLITE_SPEEDTEST_URL = https://sqlite.org/src/raw/5e5b805f24cc939656058f6a498f5a2160f9142e4815c54faf758ec798d4cdad?at=speedtest1.c
-SQLITE_SPEEDTEST_SHA1 = f0edde2ad68f090e4676ac30042e0f6b765a8528
+SQLITE_SRC = ../../tests/third_party/sqlite
+SQLITE_BENCHMARK_SRC = ../../tests/sqlite
+
 
 .PHONY: all 
-all: sqlite-speedtest emscripten-tests packager-tests jsops-tests
+all: sqlite emscripten-tests packager-tests jsops-tests
 
-## cache
-cache/$(SQLITE_AMALGAMATION).zip:
-	mkdir -p cache
-	curl -LsSf '$(SQLITE_AMALGAMATION_ZIP_URL)' -o $@
-
-cache/$(SQLITE_SPEEDTEST):
-	mkdir -p cache
-	curl -LsSf '$(SQLITE_SPEEDTEST_URL)' -o $@
-
-
-## sqlite-src
-.PHONY: sqlite-src
-sqlite-src: sqlite-src/$(SQLITE_AMALGAMATION) sqlite-src/$(SQLITE_SPEEDTEST)
-
-sqlite-src/$(SQLITE_AMALGAMATION): cache/$(SQLITE_AMALGAMATION).zip sqlite-src/$(SQLITE_AMALGAMATION)/$(EXTENSION_FUNCTIONS)
-	mkdir -p sqlite-src/$(SQLITE_AMALGAMATION)
-	echo '$(SQLITE_AMALGAMATION_ZIP_SHA1)  ./cache/$(SQLITE_AMALGAMATION).zip' > cache/check.txt
-	shasum -c cache/check.txt
-	# We don't delete the sqlite_amalgamation folder. That's a job for clean
-	# Also, the extension functions get copied here, and if we get the order of these steps wrong,
-	# this step could remove the extension functions, and that's not what we want
-	unzip -u 'cache/$(SQLITE_AMALGAMATION).zip' -d sqlite-src/
-	touch $@
-
-sqlite-src/$(SQLITE_AMALGAMATION)/$(SQLITE_H): sqlite-src/$(SQLITE_AMALGAMATION)
-
-sqlite-src/$(SQLITE_SPEEDTEST): cache/$(SQLITE_SPEEDTEST)
-	mkdir -p sqlite-src/$(SQLITE_AMALGAMATION)
-	echo '$(SQLITE_SPEEDTEST_SHA1)  ./cache/$(SQLITE_SPEEDTEST)' > cache/check.txt
-	shasum -c cache/check.txt
-	cp 'cache/$(SQLITE_SPEEDTEST)' $@
 
 # Optimization Flags
 ## With debugging flags enabled, optimization level is O0.
@@ -72,17 +34,7 @@ CFLAGS = \
 	-$(OPTIMIZATION_LEVEL) \
 	-Wall \
 	-pthread \
-	-I.. 
-
-CFLAGS_SQLITE = \
-	$(CFLAGS) \
-	-DSQLITE_ENABLE_MEMSYS5 \
-	-D_HAVE_SQLITE_CONFIG_H \
-	-DSQLITE_OMIT_LOAD_EXTENSION \
-	-DSQLITE_DISABLE_LFS \
-	-DSQLITE_THREADSAFE=0 \
-	-DSQLITE_ENABLE_NORMALIZE \
-	-Isqlite-src/$(SQLITE_AMALGAMATION)/
+	-I..
 
 # Allocate 128 MiB to prevent OOM errors in some tests.
 LINK_FLAGS =  \
@@ -92,25 +44,33 @@ LINK_FLAGS =  \
 	-s INITIAL_MEMORY=134217728 \
 	$(DEBUGGING_FLAGS)
 
-
 .PHONY: clean
 clean:
 	rm -rf dist/*
 	rm -rf out/
-	rm -f cache/*
-	rm -rf sqlite-src/
 
-$(OBJ)/sqlite3.o: sqlite-src/$(SQLITE_AMALGAMATION)
-	mkdir -p $(OBJ)
-	$(EMCC) $(CFLAGS) -c sqlite-src/$(SQLITE_AMALGAMATION)/sqlite3.c -o $@
-
-$(OBJ)/speedtest1.o: sqlite-src/$(SQLITE_SPEEDTEST) sqlite-src/$(SQLITE_AMALGAMATION)
-	mkdir -p $(OBJ)
-	$(EMCC) $(CFLAGS) -Isqlite-src/$(SQLITE_AMALGAMATION)/ -c $< -o $@
+# Don't delete my precious object files
+.PRECIOUS: $(OBJ)/%.out
 
 $(OBJ)/pthreadfs.o : $(PTHREADFS_CPP) $(PTHREADFS_H)
 	mkdir -p $(OBJ)
 	$(EMCC) -c $(CFLAGS) $< -o $@
+
+.PHONY: sqlite
+sqlite: $(addprefix dist/sqlite/, $(addsuffix .html, $(notdir $(basename $(wildcard $(SQLITE_BENCHMARK_SRC)/*.c)))))
+	@echo 'Building SQLite Tests' $?
+
+$(OBJ)/sqlite3.o: $(SQLITE_SRC)/sqlite3.c
+	mkdir -p $(OBJ)
+	$(EMCC) $(CFLAGS) -c $< -o $@
+
+$(OBJ)/sqlite/%.o : $(SQLITE_BENCHMARK_SRC)/%.c
+	mkdir -p $(OBJ)/sqlite/
+	$(EMCC) -c $(CFLAGS) -I$(SQLITE_SRC) $< -o $@
+
+dist/sqlite/%.html : $(OBJ)/sqlite/%.o $(OBJ)/pthreadfs.o $(OBJ)/sqlite3.o sqlite/sqlite-prejs.js $(PTHREADFS_JS) 
+	mkdir -p dist/sqlite/
+	$(EMCC) $(LINK_FLAGS) --js-library=$(PTHREADFS_JS) --pre-js=$(word 4,$^) $< $(word 2,$^) $(word 3,$^) -o $@
 
 $(OBJ)/%.o : $(EMTESTS)/%.cpp
 	mkdir -p $(OBJ)
@@ -119,15 +79,6 @@ $(OBJ)/%.o : $(EMTESTS)/%.cpp
 $(OBJ)/%.o : $(PACKAGERTESTS)/%.cpp
 	mkdir -p $(OBJ)
 	$(EMCC) -c $(CFLAGS) $< -o $@
-
-# Don't delete my precious object files
-.PRECIOUS: $(OBJ)/%.out
-
-.PHONY: sqlite-speedtest
-sqlite-speedtest: dist/sqlite-speedtest/index.html
-dist/sqlite-speedtest/index.html: $(OBJ)/speedtest1.o $(OBJ)/sqlite3.o $(OBJ)/pthreadfs.o $(PTHREADFS_JS) $(SQLITETESTS)/sqlite-speedtest-prejs.js
-	mkdir -p dist/sqlite-speedtest
-	$(EMCC) $(LINK_FLAGS) --pre-js=$(SQLITETESTS)/sqlite-speedtest-prejs.js --js-library=$(PTHREADFS_JS) $< $(word 2,$^) $(word 3,$^) -o $@ 
 
 .PHONY: emscripten-tests
 emscripten-tests: $(addprefix dist/, $(addsuffix .html, $(basename $(wildcard $(EMTESTS)/*.cpp))))

--- a/pthreadfs/examples/sqlite-speedtest/sqlite-speedtest-prejs.js
+++ b/pthreadfs/examples/sqlite-speedtest/sqlite-speedtest-prejs.js
@@ -1,6 +1,0 @@
-
-var Module = Module || {};
-Module['arguments'] = Module['arguments'] || [];
-Module['arguments'].push('--size');
-Module['arguments'].push('40');
-Module['arguments'].push(`/persistent/db${Math.random()}`);

--- a/pthreadfs/examples/sqlite/sqlite-prejs.js
+++ b/pthreadfs/examples/sqlite/sqlite-prejs.js
@@ -1,0 +1,15 @@
+var Module = Module || {};
+Module['arguments'] = Module['arguments'] || [];
+Module['arguments'].push('3');
+Module['arguments'].push(`/persistent/db${Math.random()}`);
+
+Module['preRun'] = Module['preRun'] || [];
+Module['preRun'].push(() => {
+  addRunDependency('remove_files');
+  navigator.storage.getDirectory().then(async (root) => {
+    for await (const entry of root.values()) {
+      await root.removeEntry(entry.name);
+    }
+    removeRunDependency('remove_files');
+  });
+});

--- a/tests/sqlite/benchmark.c
+++ b/tests/sqlite/benchmark.c
@@ -39,7 +39,7 @@ int test(){
     NULL
   };
 
-  rc = sqlite3_open(":memory:", &db);
+  rc = sqlite3_open("/persistent/benchmark_db_test", &db);
   if( rc ){
     fprintf(stderr, "Can't open database: %s\n", sqlite3_errmsg(db));
     sqlite3_close(db);
@@ -67,7 +67,7 @@ int main(int argc, char **argv){
   n = argc > 1 ? atoi(argv[1]) : 5000;
   m = argc > 2 ? atoi(argv[2]) : 1;
 
-  rc = sqlite3_open(":memory:", &db);
+  rc = sqlite3_open("/persistent/benchmark_db_main", &db);
   if( rc ){
     fprintf(stderr, "Can't open database: %s\n", sqlite3_errmsg(db));
     sqlite3_close(db);

--- a/tests/sqlite/speedtest1.c
+++ b/tests/sqlite/speedtest1.c
@@ -1304,7 +1304,7 @@ int main(int argc, char **argv){
   }
  
   /* Open the database and the input file */
-  if( sqlite3_open(":memory:", &g.db) ){
+  if( sqlite3_open(zDbName, &g.db) ){
     fatal_error("Cannot open database file: %s\n", zDbName);
   }
   if( nLook>0 && szLook>0 ){

--- a/tests/sqlite/test.c
+++ b/tests/sqlite/test.c
@@ -32,7 +32,7 @@ int main(){
     NULL
   };
 
-  rc = sqlite3_open(":memory:", &db);
+  rc = sqlite3_open("persistent/db_test", &db);
   if( rc ){
     fprintf(stderr, "Can't open database: %s\n", sqlite3_errmsg(db));
     sqlite3_close(db);


### PR DESCRIPTION
With this change, PThreadFS re-uses the SQLite tests performed by Emscripten.

The changes to `tests/sqlite` ensure that the tests don't use an in-memory database. The pre-js script removes any old data before running the tests and sets the options for `speedtest1.c`.