### PR TITLE
Fix rename

### DIFF
--- a/pthreadfs/README.md
+++ b/pthreadfs/README.md
@@ -76,6 +76,7 @@ See `pthreadfs/examples/emscripten-tests/fsafs.cpp` for exemplary usage.
 - Accessing the file system before `main()` requires linker option `PTHREAD_POOL_SIZE=<expression>` to be active. Doing so may lead to some blocking of the main thread, which is risky. Check out `examples/early_syscall.cpp` for an example.
 - Compiling with the Closure Compiler is not supported.
 - Compiling with optimization `-O3` is not yet supported and may lead to a faulty build.
+- Directories cannot be renamed when using OPFS Access Handles. This is currently a limitation of the underlying API.
 
 ## Examples
 

--- a/pthreadfs/examples/emscripten-tests/rename.cpp
+++ b/pthreadfs/examples/emscripten-tests/rename.cpp
@@ -1,88 +1,141 @@
-#include <iostream>
-#include <fstream>
-#include <cstdio>
-#include <emscripten.h>
+/*
+ * Copyright 2013 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
 
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
 
-int main()
-{
-  std::cout << "Start Rename test\n";
+// PThreadFS currently does not allow renaming or moving directories.
+#define PTHREADFS_NO_DIR_RENAME
 
-  // MEMFS file that is closed when renaming.
+void create_file(const char *path, const char *buffer, int mode) {
+  int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, mode);
+  assert(fd >= 0);
 
-  std::ofstream closed_memfs_file;
-  closed_memfs_file.open ("old_closed_memfs_file");
-  closed_memfs_file << "Contents of closed_memfs_file.";
-  closed_memfs_file.close();
- 
-  if (std::rename("old_closed_memfs_file", "new_closed_memfs_file")) {
-    std::cout << "Error renaming closed_memfs_file\n";
-    return 1;
-  }
-  std::cout << "Rename closed_memfs_file successfully\n";
+  int err = write(fd, buffer, sizeof(char) * strlen(buffer));
+  assert(err ==  (sizeof(char) * strlen(buffer)));
 
-  if(std::remove("new_closed_memfs_file")) {
-    std::cout << "Removing closed_memfs_file failed\n";
-    return 1;
-  }
-  std::cout << "Removed closed_memfs_file\n";
+  close(fd);
+}
 
-  // MEMFS file that is open when renaming.
+void setup() {
+  create_file("persistent/file", "abcdef", 0777);
+  mkdir("persistent/dir", 0777);
+  create_file("persistent/dir/file", "abcdef", 0777);
+  mkdir("persistent/dir/subdir", 0777);
+  mkdir("persistent/dir-readonly", 0555);
+  mkdir("persistent/dir-nonempty", 0777);
+  mkdir("persistent/dir/subdir3", 0777);
+  mkdir("persistent/dir/subdir3/subdir3_1", 0777);
+  mkdir("persistent/dir/subdir4/", 0777);
+  create_file("persistent/dir-nonempty/file", "abcdef", 0777);
+}
 
-  std::ofstream open_memfs_file;
-  open_memfs_file.open ("old_open_memfs_file");
-  open_memfs_file << "Contents of open_memfs_file.";
- 
-  if (std::rename("old_open_memfs_file", "new_open_memfs_file")) {
-    std::cout << "Error renaming open_memfs_file\n";
-    return 1;
-  }
-  std::cout << "Rename open_memfs_file successfully\n";
-  open_memfs_file.close();
+void cleanup() {
+  // we're hulk-smashing and removing original + renamed files to
+  // make sure we get it all regardless of anything failing
+  unlink("persistent/file");
+  unlink("persistent/dir/file");
+  unlink("persistent/dir/file1");
+  unlink("persistent/dir/file2");
+  rmdir("persistent/dir/subdir");
+  rmdir("persistent/dir/subdir1");
+  rmdir("persistent/dir/subdir2");
+  rmdir("persistent/dir/subdir3/subdir3_1/subdir1 renamed");
+  rmdir("persistent/dir/subdir3/subdir3_1");
+  rmdir("persistent/dir/subdir3");
+  rmdir("persistent/dir/subdir4/");
+  rmdir("persistent/dir/subdir5/");
+  rmdir("persistent/dir");
+  rmdir("persistent/dir-readonly");
+  unlink("persistent/dir-nonempty/file");
+  rmdir("persistent/dir-nonempty");
+}
 
-  if(std::remove("new_open_memfs_file")) {
-    std::cout << "Removing open_memfs_file failed\n";
-    return 1;
-  }
-  std::cout << "Removed open_memfs_file\n";
+void test() {
+  int err;
 
-  // PThreadFS file that is closed when renaming.
-  std::ofstream closed_pthreadfs_file;
-  closed_pthreadfs_file.open ("persistent/old_closed_pthreadfs_file");
-  closed_pthreadfs_file << "Contents of closed_pthreadfs_file.";
-  closed_pthreadfs_file.close();
- 
-  if (std::rename("persistent/old_closed_pthreadfs_file", "persistent/new_closed_pthreadfs_file")) {
-    std::cout << "Error renaming closed_pthreadfs_file\n";
-    return 1;
-  }
-  std::cout << "Rename closed_pthreadfs_file successfully\n";
-  closed_pthreadfs_file.close();
+  // can't rename something that doesn't exist
+  err = rename("persistent/noexist", "persistent/dir");
+  assert(err == -1);
+  assert(errno == ENOENT);
 
-  if(std::remove("persistent/new_closed_pthreadfs_file")) {
-    std::cout << "Removing closed_pthreadfs_file failed\n";
-    return 1;
-  }
-  std::cout << "Removed closed_pthreadfs_file\n";
+  // can't overwrite a folder with a file
+  err = rename("persistent/file", "persistent/dir");
+  assert(err == -1);
+  assert(errno == EISDIR);
 
-  // PThreadFS file that is open when renaming.
-  std::ofstream open_pthreadfs_file;
-  open_pthreadfs_file.open ("persistent/old_open_pthreadfs_file");
-  open_pthreadfs_file << "Contents of open_pthreadfs_file.";
- 
-  if (std::rename("persistent/old_open_pthreadfs_file", "persistent/new_open_pthreadfs_file")) {
-    std::cout << "Error renaming open_pthreadfs_file\n";
-    return 1;
-  }
-  std::cout << "Rename open_pthreadfs_file successfully\n";
-  open_pthreadfs_file.close();
+  // can't overwrite a file with a folder
+  err = rename("persistent/dir", "persistent/file");
+  assert(err == -1);
+  assert(errno == ENOTDIR);
 
-  if(std::remove("persistent/new_open_pthreadfs_file")) {
-    std::cout << "Removing open_pthreadfs_file failed.\n";
-    std::cout << "This is expected when using the OPFS backend.\n";
-    return 1;
-  }
-  std::cout << "Removed open_pthreadfs_file\n";
+  // can't overwrite a non-empty folder
+  err = rename("persistent/dir", "persistent/dir-nonempty");
+  assert(err == -1);
+  assert(errno == ENOTEMPTY);
 
-  std::cout << "Success\n";
+  // can't create anything in a read-only directory
+  err = rename("persistent/dir", "persistent/dir-readonly/dir");
+  assert(err == -1);
+  assert(errno == EACCES);
+
+  // source should not be ancestor of target
+  err = rename("persistent/dir", "persistent/dir/somename");
+  assert(err == -1);
+  assert(errno == EINVAL);
+
+  // target should not be an ancestor of source
+  err = rename("persistent/dir/subdir", "persistent/dir");
+  assert(err == -1);
+  assert(errno == ENOTEMPTY);
+
+  // do some valid renaming
+  err = rename("persistent/dir/file", "persistent/dir/file1");
+  assert(!err);
+  err = rename("persistent/dir/file1", "persistent/dir/file2");
+  assert(!err);
+  err = access("persistent/dir/file2", F_OK);
+  assert(!err);
+
+#ifndef PTHREADFS_NO_DIR_RENAME
+  err = rename("persistent/dir/subdir", "persistent/dir/subdir1");
+  assert(!err);
+  err = rename("persistent/dir/subdir1", "persistent/dir/subdir2");
+  assert(!err);
+  err = access("persistent/dir/subdir2", F_OK);
+  assert(!err);
+
+  err = rename("persistent/dir/subdir2", "persistent/dir/subdir3/subdir3_1/subdir1 renamed");
+  assert(!err);
+  err = access("persistent/dir/subdir3/subdir3_1/subdir1 renamed", F_OK);
+  assert(!err);
+
+  // test that non-existant parent during rename generates the correct error code
+  err = rename("persistent/dir/hicsuntdracones/empty", "persistent/dir/hicsuntdracones/renamed");
+  assert(err == -1);
+  assert(errno == ENOENT);
+  
+  err = rename("persistent/dir/subdir4/", "persistent/dir/subdir5/");
+  assert(!err);
+#endif  // PTHREADFS_NO_DIR_RENAME
+
+  puts("success");
+}
+
+int main() {
+  setup();
+  test();
+  cleanup();
+  return EXIT_SUCCESS;
 }

--- a/pthreadfs/examples/emscripten-tests/rename.cpp
+++ b/pthreadfs/examples/emscripten-tests/rename.cpp
@@ -80,6 +80,7 @@ void test() {
   assert(err == -1);
   assert(errno == ENOTDIR);
 
+#ifndef PTHREADFS_NO_DIR_RENAME
   // can't overwrite a non-empty folder
   err = rename("persistent/dir", "persistent/dir-nonempty");
   assert(err == -1);
@@ -99,6 +100,7 @@ void test() {
   err = rename("persistent/dir/subdir", "persistent/dir");
   assert(err == -1);
   assert(errno == ENOTEMPTY);
+#endif  // PTHREADFS_NO_DIR_RENAME
 
   // do some valid renaming
   err = rename("persistent/dir/file", "persistent/dir/file1");

--- a/pthreadfs/examples/emscripten-tests/rename_backends.cpp
+++ b/pthreadfs/examples/emscripten-tests/rename_backends.cpp
@@ -1,0 +1,88 @@
+#include <iostream>
+#include <fstream>
+#include <cstdio>
+#include <emscripten.h>
+
+
+int main()
+{
+  std::cout << "Start Rename test\n";
+
+  // MEMFS file that is closed when renaming.
+
+  std::ofstream closed_memfs_file;
+  closed_memfs_file.open ("old_closed_memfs_file");
+  closed_memfs_file << "Contents of closed_memfs_file.";
+  closed_memfs_file.close();
+ 
+  if (std::rename("old_closed_memfs_file", "new_closed_memfs_file")) {
+    std::cout << "Error renaming closed_memfs_file\n";
+    return 1;
+  }
+  std::cout << "Rename closed_memfs_file successfully\n";
+
+  if(std::remove("new_closed_memfs_file")) {
+    std::cout << "Removing closed_memfs_file failed\n";
+    return 1;
+  }
+  std::cout << "Removed closed_memfs_file\n";
+
+  // MEMFS file that is open when renaming.
+
+  std::ofstream open_memfs_file;
+  open_memfs_file.open ("old_open_memfs_file");
+  open_memfs_file << "Contents of open_memfs_file.";
+ 
+  if (std::rename("old_open_memfs_file", "new_open_memfs_file")) {
+    std::cout << "Error renaming open_memfs_file\n";
+    return 1;
+  }
+  std::cout << "Rename open_memfs_file successfully\n";
+  open_memfs_file.close();
+
+  if(std::remove("new_open_memfs_file")) {
+    std::cout << "Removing open_memfs_file failed\n";
+    return 1;
+  }
+  std::cout << "Removed open_memfs_file\n";
+
+  // PThreadFS file that is closed when renaming.
+  std::ofstream closed_pthreadfs_file;
+  closed_pthreadfs_file.open ("persistent/old_closed_pthreadfs_file");
+  closed_pthreadfs_file << "Contents of closed_pthreadfs_file.";
+  closed_pthreadfs_file.close();
+ 
+  if (std::rename("persistent/old_closed_pthreadfs_file", "persistent/new_closed_pthreadfs_file")) {
+    std::cout << "Error renaming closed_pthreadfs_file\n";
+    return 1;
+  }
+  std::cout << "Rename closed_pthreadfs_file successfully\n";
+  closed_pthreadfs_file.close();
+
+  if(std::remove("persistent/new_closed_pthreadfs_file")) {
+    std::cout << "Removing closed_pthreadfs_file failed\n";
+    return 1;
+  }
+  std::cout << "Removed closed_pthreadfs_file\n";
+
+  // PThreadFS file that is open when renaming.
+  std::ofstream open_pthreadfs_file;
+  open_pthreadfs_file.open ("persistent/old_open_pthreadfs_file");
+  open_pthreadfs_file << "Contents of open_pthreadfs_file.";
+ 
+  if (std::rename("persistent/old_open_pthreadfs_file", "persistent/new_open_pthreadfs_file")) {
+    std::cout << "Error renaming open_pthreadfs_file\n";
+    return 1;
+  }
+  std::cout << "Rename open_pthreadfs_file successfully\n";
+  open_pthreadfs_file.close();
+
+  if(std::remove("persistent/new_open_pthreadfs_file")) {
+    std::cout << "Removing open_pthreadfs_file failed.\n";
+    std::cout << "This is expected when using the OPFS backend.\n";
+    return 1;
+  }
+  std::cout << "Removed open_pthreadfs_file\n";
+
+  std::cout << "Success\n";
+}

--- a/pthreadfs/library_pthreadfs.js
+++ b/pthreadfs/library_pthreadfs.js
@@ -3187,6 +3187,9 @@ mergeInto(LibraryManager.library, {
 
       rename: async function (oldNode, newParentNode, newName) {
         FSAFS.debug('rename', arguments);
+        if (oldNode.contents && Object.keys(oldNode.contents).length > 0) {
+          throw new PThreadFS.ErrnoError({{{ cDefine('ENOTEMPTY') }}});
+        }
         try {
           await oldNode.localReference.move(newParentNode.localReference, newName);
         }
@@ -3206,6 +3209,13 @@ mergeInto(LibraryManager.library, {
           }
           throw new PThreadFS.ErrnoError({{{ cDefine('EXDEV') }}});
         }
+        // Update the internal directory cache.
+        delete oldNode.parent.contents[oldNode.name];
+        oldNode.parent.timestamp = Date.now()
+        oldNode.name = newName;
+        newParentNode.contents[newName] = oldNode;
+        newParentNode.timestamp = oldNode.parent.timestamp;
+        oldNode.parent = newParentNode;
       },
 
       unlink: async function(parent, name) {

--- a/pthreadfs/library_pthreadfs.js
+++ b/pthreadfs/library_pthreadfs.js
@@ -3187,8 +3187,9 @@ mergeInto(LibraryManager.library, {
 
       rename: async function (oldNode, newParentNode, newName) {
         FSAFS.debug('rename', arguments);
-        if (oldNode.contents && Object.keys(oldNode.contents).length > 0) {
-          throw new PThreadFS.ErrnoError({{{ cDefine('ENOTEMPTY') }}});
+        if (PThreadFS.isDir(oldNode.mode)) {
+          console.log('Rename error: File System Access does not support renaming directories');
+          throw new PThreadFS.ErrnoError({{{ cDefine('EXDEV') }}});
         }
         try {
           await oldNode.localReference.move(newParentNode.localReference, newName);

--- a/pthreadfs/src/js/library_fsafs.js
+++ b/pthreadfs/src/js/library_fsafs.js
@@ -189,8 +189,9 @@ mergeInto(LibraryManager.library, {
 
       rename: async function (oldNode, newParentNode, newName) {
         FSAFS.debug('rename', arguments);
-        if (oldNode.contents && Object.keys(oldNode.contents).length > 0) {
-          throw new PThreadFS.ErrnoError({{{ cDefine('ENOTEMPTY') }}});
+        if (PThreadFS.isDir(oldNode.mode)) {
+          console.log('Rename error: File System Access does not support renaming directories');
+          throw new PThreadFS.ErrnoError({{{ cDefine('EXDEV') }}});
         }
         try {
           await oldNode.localReference.move(newParentNode.localReference, newName);


### PR DESCRIPTION
This PR fixes a bug that rename not update the internal directory cache. It also gives a clear error message when trying to rename directories, which is unsupported by OPFS Access Handles.

Additionally, this moves the old rename test to rename_backends.cpp and instead uses the standard emscripten test as rename.cpp