### PR TITLE
[DO NOT MERGE] Sample library for WasmFS with OPFS

### DIFF
--- a/pthreadfs/library_wasmfs_opfs.js
+++ b/pthreadfs/library_wasmfs_opfs.js
@@ -20,11 +20,11 @@ mergeInto(LibraryManager.library, {
       // Open directory `name` under `parent` and create it if it does not exist. Map the result to
       // handle `directory_id`.
       createOrOpenDirectoryHandle : async (directory_id, name, parent) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSDirectoryHandles[parent]);
         // We should not carelessly overwrite directory ids.
         assert(!wasmFS$OPFSDirectoryHandles.hasOwnProperty(directory_id));
-// #endif
+#endif
         let parent_handle = wasmFS$OPFSDirectoryHandles[parent];
         let handle;
         try {
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
         } catch (err) {
           if (err.name === 'TypeMismatchError') {
             // A file of the same name already exists.
-            // return {{{ cDefine('EEXISTS') }}};
+            return {{{ cDefine('EEXISTS') }}};
           } else {
             // TODO: Add graceful failure.
             abort("Unknown error in createOrOpenDirectoryHandle");
@@ -45,17 +45,17 @@ mergeInto(LibraryManager.library, {
       // Removes the directory handle `directory_id` refers to from the set of directory handles.
       // This does not remove the directory from the storage backend.
       closeDirectoryHandle : async (directory_id) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSDirectoryHandles[directory_id]);
-// #endif
+#endif
         delete wasmFS$OPFSDirectoryHandles[directory_id];
       },
 
       // Returns true iff directory `directory_name` exists under `parent`.
       directoryExists : async (directory_name, parent) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSDirectoryHandles[parent]);
-// #endif
+#endif
         let parent_handle = wasmFS$OPFSDirectoryHandles[parent];
         try {
           await parent_handle.getDirectoryHandle(directory_name, {create : false});
@@ -66,9 +66,9 @@ mergeInto(LibraryManager.library, {
       },
       // Returns true iff file `file_name` exists under `parent`.
       fileExists : async (file_name, parent) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSDirectoryHandles[parent]);
-// #endif
+#endif
         let parent_handle = wasmFS$OPFSDirectoryHandles[parent];
         try {
           await parent_handle.getFileHandle(file_name, {create : false});
@@ -82,9 +82,9 @@ mergeInto(LibraryManager.library, {
       // A directory can only be reomved if it is empty.
       // Files with open access handles cannot be removed.
       removeFileOrDirectory : async (name, parent) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSDirectoryHandles[parent]);
-// #endif
+#endif
         let parent_handle = wasmFS$OPFSDirectoryHandles[parent];
         await parent_handle.removeEntry(name);
         return 0;
@@ -93,9 +93,9 @@ mergeInto(LibraryManager.library, {
       // Returns all files and directories under `directory_id`.
       // TODO: Do we need separate methods to retrieve files and directories?
       getDirectoryEntries : async (directory_id) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSDirectoryHandles[directory_id]);
-// #endif
+#endif
         let directory_handle = wasmFS$OPFSDirectoryHandles[directory_id];
         // TODO Consider refactoring this to use `for await` once that is supported by Emscripten's
         // minifier.
@@ -116,11 +116,11 @@ mergeInto(LibraryManager.library, {
       // Only a single access handle per file can exist over all Javascript contexts.
       // TODO: Add graceful error handling if an access handle already exists.
       createOrOpenFile : async (file_id, name, parent) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSDirectoryHandles[parent]);
         // We should not carelessly overwrite file ids.
         assert(!wasmFS$OPFSAccessHandles.hasOwnProperty(file_id));
-// #endif
+#endif
         let parent_handle = wasmFS$OPFSDirectoryHandles[parent];
         let file_handle = await parent_handle.getFileHandle(name, {create : true});
         let access_handle;
@@ -142,9 +142,9 @@ mergeInto(LibraryManager.library, {
       },
       // Closes the access handle associated with `file_id`.
       close : async (file_id) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSAccessHandles[file_id]);
-// #endif
+#endif
         let file_handle = wasmFS$OPFSAccessHandles[file_id];
         await file_handle.close();
         delete wasmFS$OPFSAccessHandles[file_id];
@@ -153,9 +153,9 @@ mergeInto(LibraryManager.library, {
       // Pick `length` files from linear memory, starting at `buffer` and write them to the file
       // starting at `offset`. Returns the number of bytes written.
       write : async (file_id, buffer, length, offset) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSAccessHandles[file_id]);
-// #endif
+#endif
         let file_handle = wasmFS$OPFSAccessHandles[file_id];
         let data = HEAPU8.subarray(buffer, buffer + length);
         let writtenBytes = await file_handle.write(data, {at : offset});
@@ -164,9 +164,9 @@ mergeInto(LibraryManager.library, {
       // Read `length` bytes from the file, starting at `offset` and write them to linear memory,
       // starting at position `buffer`. Returns the number of bytes read.
       read : async (file_id, buffer, length, offset) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSAccessHandles[file_id]);
-// #endif
+#endif
         let file_handle = wasmFS$OPFSAccessHandles[file_id];
         let data = HEAPU8.subarray(buffer, buffer + length);
         let readBytes = await file_handle.read(data, {at : offset});
@@ -174,18 +174,18 @@ mergeInto(LibraryManager.library, {
       },
       // Return the file's size in bytes.
       getSize : async (file_id) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSAccessHandles[file_id]);
-// #endif
+#endif
         let file_handle = wasmFS$OPFSAccessHandles[file_id];
         return await file_handle.getSize();
       },
       // If `new_size` is smaller than the file's current size, truncate the file associated with
       // `file_id` to `new_size`. Otherwise, pad the file with zeroes until its size is `new_size`.
       setSize : async (file_id, new_size) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSAccessHandles[file_id]);
-// #endif
+#endif
         let file_handle = wasmFS$OPFSAccessHandles[file_id];
         await file_handle.truncate(new_size);
         return 0;
@@ -193,9 +193,9 @@ mergeInto(LibraryManager.library, {
       // Flushes the access handle associated with `file_id`. This implements the behavior of 
       // syscalls fsync and fdatasync.
       flush : async (file_id) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSAccessHandles[file_id]);
-// #endif
+#endif
         let file_handle = wasmFS$OPFSAccessHandles[file_id];
         await file_handle.flush();
         return 0;
@@ -215,11 +215,11 @@ mergeInto(LibraryManager.library, {
       // Open file `name` under `parent` and create it if it does not exist. Map the result to
       // non-locking handle `file_id`.
       createOrOpenFileNonLocking : async (file_id, name, parent) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSDirectoryHandles[parent]);
         // We should not carelessly overwrite non-locking file ids.
         assert(!wasmFS$OPFS.hasOwnProperty(file_id));
-// #endif
+#endif
         let parent_handle = wasmFS$OPFSDirectoryHandles[parent];
         let file_handle = await parent_handle.getFileHandle(name, {create : true});
         wasmFS$OPFSNonLockingFileHandles[file_id] = file_handle;
@@ -227,18 +227,18 @@ mergeInto(LibraryManager.library, {
       },
       // Closes the non-locking handle associated with `file_id`.
       closeNonLocking : async (file_id) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSNonLockingFileHandles[file_id]);
-// #endif
+#endif
         delete wasmFS$OPFSNonLockingFileHandles[file_id];
         return 0;
       },
       // Read from a non-locking handle `length` bytes from the file, starting at `offset` and 
       // write them to linear memory, starting at position `buffer`. 
       readNonLocking : async (file_id, buffer, length, offset) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSNonLockingFileHandles[file_id]);
-// #endif
+#endif
         let file_blob = await wasmFS$OPFSNonLockingFileHandles[file_id].getFile();
         let file_arraybuffer = await file_blob.arrayBuffer();
         var file_uint8view = new Uint8Array(file_arraybuffer);
@@ -249,9 +249,9 @@ mergeInto(LibraryManager.library, {
       },
       // Return the file's size in bytes from a non-locking handle.
       getSizeNonLocking : async (file_id) => {
-// #if ASSERTIONS
+#if ASSERTIONS
         assert(wasmFS$OPFSNonLockingFileHandles[file_id]);
-// #endif
+#endif
         let file_blob = await wasmFS$OPFSNonLockingFileHandles[file_id].getFile();
         return file_blob.size;
       },


### PR DESCRIPTION
This demonstrates how the Javascript side of an OPFS backend for WasmFS might look like.

With the library, the (C++) caller associates a unique id (file_id or directory_id) with each file. The Javascript library creates a mapping between the id and the OPFS handle.

The Javascript code is split into three parts:
- Directory operations: Creating, listing and removing directories.
- File operations: These operations open files using OPFS Access Handles. Only a single access handle per file can exist along all javascript contexts, i.e. opening a file locks it for all other workers / tabs.
- Non-locking file operations: These operations open files using file blobs, which do not lock the file. See the long inline comment for more information.

This code is not well-tested, since the remainder of the WasmFS infrastructure is not yet finished.