### PR TITLE
Remove the ENOSYS for readlink, which fixes realpath

### DIFF
--- a/pthreadfs/library_pthreadfs.js
+++ b/pthreadfs/library_pthreadfs.js
@@ -3230,6 +3230,9 @@ mergeInto(LibraryManager.library, {
         return entries;
       },
 
+      // No readlink support: Since PThreadFS does not support links, there is
+      // no need for readlink at this time.
+
       symlink: function(parent, newName, oldPath) {
         console.log('FSAFS error: symlink is not implemented')
         throw new PThreadFS.ErrnoError({{{ cDefine('EXDEV') }}});

--- a/pthreadfs/library_pthreadfs.js
+++ b/pthreadfs/library_pthreadfs.js
@@ -3234,11 +3234,6 @@ mergeInto(LibraryManager.library, {
         console.log('FSAFS error: symlink is not implemented')
         throw new PThreadFS.ErrnoError({{{ cDefine('EXDEV') }}});
       },
-
-      readlink: function(node) {
-        console.log('FSAFS error: readlink is not implemented')
-        throw new PThreadFS.ErrnoError({{{ cDefine('ENOSYS') }}});
-      },
     },
 
     /* Operations on file streams (i.e., file handles) */

--- a/pthreadfs/src/js/library_fsafs.js
+++ b/pthreadfs/src/js/library_fsafs.js
@@ -269,11 +269,6 @@ mergeInto(LibraryManager.library, {
         console.log('FSAFS error: symlink is not implemented')
         throw new PThreadFS.ErrnoError({{{ cDefine('EXDEV') }}});
       },
-
-      readlink: function(node) {
-        console.log('FSAFS error: readlink is not implemented')
-        throw new PThreadFS.ErrnoError({{{ cDefine('ENOSYS') }}});
-      },
     },
 
     /* Operations on file streams (i.e., file handles) */

--- a/pthreadfs/src/js/library_fsafs.js
+++ b/pthreadfs/src/js/library_fsafs.js
@@ -265,6 +265,9 @@ mergeInto(LibraryManager.library, {
         return entries;
       },
 
+      // No readlink support: Since PThreadFS does not support links, there is
+      // no need for readlink at this time.
+
       symlink: function(parent, newName, oldPath) {
         console.log('FSAFS error: symlink is not implemented')
         throw new PThreadFS.ErrnoError({{{ cDefine('EXDEV') }}});


### PR DESCRIPTION
This removes the ENOSYS message for readlink under OPFS, which fixes the realpath. Note that this only works since PThreadFS does not support links.

Context: https://github.com/emscripten-core/emscripten/blob/main/system/lib/libc/musl/src/misc/realpath.c