### PR TITLE
Fix compilation with -O3 optimization

### DIFF
--- a/pthreadfs/README.md
+++ b/pthreadfs/README.md
@@ -70,7 +70,6 @@ PThreadFS supports pre-loading files through the file packager. More information
 - PThreadFS depends on C++ libraries. `EM_PTHREADFS_ASM()` cannot be used within C files.
 - Accessing the file system before `main()` requires linker option `PTHREAD_POOL_SIZE=<expression>` to be active. Doing so may lead to some blocking of the main thread, which is risky. Check out `examples/early_syscall.cpp` for an example.
 - Compiling with the Closure Compiler is not supported.
-- Compiling with optimization `-O3` is not yet supported and may lead to a faulty build.
 - Directories cannot be renamed when using OPFS Access Handles. This is currently a limitation of the underlying API.
 
 ## Examples

--- a/pthreadfs/pthreadfs.h
+++ b/pthreadfs/pthreadfs.h
@@ -47,10 +47,12 @@ EM_IMPORT(__syscall_##name)  long SYNC_JS_SYSCALL(name)(__VA_ARGS__);
 
 #define WASI_JSAPI_DEF(name, ...)                                                                  \
   extern void __fd_##name##_async(__wasi_fd_t fd, __VA_ARGS__, void (*fun)(__wasi_errno_t));       \
-  extern __wasi_errno_t fd_##name(__wasi_fd_t fd, __VA_ARGS__);
+  __attribute__((__import_module__("wasi_snapshot_preview1"), __import_name__(QUOTE(fd_##name))))       \
+  EM_IMPORT(fd_##name) __wasi_errno_t fd_##name(__wasi_fd_t fd, __VA_ARGS__);
 #define WASI_JSAPI_NOARGS_DEF(name)                                                                \
   extern void __fd_##name##_async(__wasi_fd_t fd, void (*fun)(__wasi_errno_t));                    \
-  extern __wasi_errno_t fd_##name(__wasi_fd_t fd);
+  __attribute__((__import_module__("wasi_snapshot_preview1"), __import_name__(QUOTE(fd_##name))))       \
+  EM_IMPORT(fd_##name) __wasi_errno_t fd_##name(__wasi_fd_t fd);
 
 #define WASI_CAPI_DEF(name, ...) __wasi_errno_t __wasi_fd_##name(__wasi_fd_t fd, __VA_ARGS__)
 #define WASI_CAPI_NOARGS_DEF(name) __wasi_errno_t __wasi_fd_##name(__wasi_fd_t fd)


### PR DESCRIPTION
Compilation with `-O3` has been broken due to an Emscripten bug, but their team pointed me to a workaround, see https://github.com/emscripten-core/emscripten/issues/16294