### PR TITLE
Use `modifyFunction` in `wrapSyscallFunction`

### DIFF
--- a/pthreadfs/library_pthreadfs.js
+++ b/pthreadfs/library_pthreadfs.js
@@ -950,13 +950,10 @@ function wrapSyscallFunction(x, library, isWasi) {
   }
   post = handler + post;
 
-  if (pre) {
-    var bodyStart = t.indexOf('{') + 1;
-    t = t.substring(0, bodyStart) + pre + t.substring(bodyStart);
-  }
-  if (post) {
-    var bodyEnd = t.lastIndexOf('}');
-    t = t.substring(0, bodyEnd) + post + t.substring(bodyEnd);
+  if (pre || post) {
+    t = modifyFunction(t, function(name, args, body, async_) {
+      return `${async_}function ${name}(${args}) {\n${pre}${body}${post}}\n`;
+    });
   }
   library[x] = eval('(' + t + ')');
   if (!library[x + '__deps']) library[x + '__deps'] = [];


### PR DESCRIPTION
This avoids problems where the existing code would incorrectly treat a type
annotation on a function parameter as the beginning of the function, leading to
syntactically invalid modified functions.

Depends on https://github.com/emscripten-core/emscripten/pull/16565.