### PR TITLE
Remove utime implementation

### DIFF
--- a/pthreadfs/library_pthreadfs.js
+++ b/pthreadfs/library_pthreadfs.js
@@ -83,54 +83,6 @@ for (x of SyscallsFunctions) {
   createSyscallWrapper(x.name, x.args, SyscallWrappers);
 }
 
-SyscallWrappers['utime_sync'] =
-  function(folder_ref, resume) {
-  let folder = UTF8ToString(folder_ref);
-
-  PThreadFS.init(folder).then(async () => {
-    // Load packaged data added during --pre-js.
-    await PThreadFS.loadAvailablePackages();
-    wasmTable.get(resume)();
-  });
-}
-
-// This is copied from utime() as defined in library.js.
-SyscallWrappers['utime_sync__deps'] = ['$FS', '$setFileTime'];
-SyscallWrappers['utime_sync__proxy'] = 'sync';
-SyscallWrappers['utime_sync__sig'] = 'iii';
-SyscallWrappers['utime_sync'] = function(path, times) {
-  // int utime(const char *path, const struct utimbuf *times);
-  // http://pubs.opengroup.org/onlinepubs/009695399/basedefs/utime.h.html
-  var time;
-  if (times) {
-    // NOTE: We don't keep track of access timestamps.
-    time = {{{ makeGetValue('times', C_STRUCTS.utimbuf.modtime, 'i32') }}} * 1000;
-  } else {
-    time = Date.now();
-  }
-  return setFileTime(path, time);
-};
-
-SyscallWrappers['utime_async'] = function(path, times, resume) {
-  var time;
-  if (times) {
-    // NOTE: We don't keep track of access timestamps.
-    time = {{{ makeGetValue('times', C_STRUCTS.utimbuf.modtime, 'i32') }}} * 1000;
-  } else {
-    time = Date.now();
-  }
-  path = UTF8ToString(path);
-  try {
-    PThreadFS.utime(path, time, time).then(() => {
-      wasmTable.get(resume)(0);
-    });
-  } catch (e) {
-    if (!(e instanceof PThreadFS.ErrnoError)) throw e + ' : ' + stackTrace();
-    setErrNo(e.errno);
-    wasmTable.get(resume)(-1);
-  }
-};
-
 SyscallWrappers['pthreadfs_init'] =
   function(folder_ref, resume) {
   let folder = UTF8ToString(folder_ref);

--- a/pthreadfs/library_pthreadfs.js
+++ b/pthreadfs/library_pthreadfs.js
@@ -950,13 +950,10 @@ function wrapSyscallFunction(x, library, isWasi) {
   }
   post = handler + post;
 
-  if (pre) {
-    var bodyStart = t.indexOf('{') + 1;
-    t = t.substring(0, bodyStart) + pre + t.substring(bodyStart);
-  }
-  if (post) {
-    var bodyEnd = t.lastIndexOf('}');
-    t = t.substring(0, bodyEnd) + post + t.substring(bodyEnd);
+  if (pre || post) {
+    t = modifyFunction(t, function(name, args, body, async_) {
+      return `${async_}function ${name}(${args}) {\n${pre}${body}${post}}\n`;
+    });
   }
   library[x] = eval('(' + t + ')');
   if (!library[x + '__deps']) library[x + '__deps'] = [];

--- a/pthreadfs/pthreadfs.cpp
+++ b/pthreadfs/pthreadfs.cpp
@@ -387,19 +387,6 @@ SYS_CAPI_DEF(
   SYS_SYNC_TO_ASYNC_FD(fallocate, fd, mode, off_low, off_high, len_low, len_high);
 }
 
-long utime(long path_ref, long times) {
-  std::string path((char*)path_ref);
-  if (emscripten::is_pthreadfs_file(path)) {
-    g_sync_to_async_helper.invoke(
-      [path_ref, times](emscripten::sync_to_async::Callback resume) {
-        g_resumeFct = [resume]() { (*resume)(); };
-        utime_async(path_ref, times, &resumeWrapper_l);
-      });
-    return resume_result_long;
-  }
-  return utime_sync(path_ref, times);
-}
-
 // Define global variables to be populated by resume;
 std::function<void()> g_resumeFct;
 emscripten::sync_to_async g_sync_to_async_helper __attribute__((init_priority(102)));

--- a/pthreadfs/pthreadfs.h
+++ b/pthreadfs/pthreadfs.h
@@ -233,12 +233,6 @@ SYS_CAPI_DEF(
 SYS_JSAPI_DEF(
   fallocate, long fd, long mode, long off_low, long off_high, long len_low, long len_high)
 
-// Emscripten implements utime directly through library.js. We copy that code 
-// to utime_sync in order to avoid name confusion. utime_async proxies the
-// calls to the IO thread.
-extern long utime_sync(long path_ref, long times);
-extern void utime_async(long path_ref, long times, void (*fun)(long));
-long utime(long path_ref, long times);
 } // extern "C"
 
 namespace emscripten {

--- a/pthreadfs/src/js/pthreadfs.js
+++ b/pthreadfs/src/js/pthreadfs.js
@@ -83,54 +83,6 @@ for (x of SyscallsFunctions) {
   createSyscallWrapper(x.name, x.args, SyscallWrappers);
 }
 
-SyscallWrappers['utime_sync'] =
-  function(folder_ref, resume) {
-  let folder = UTF8ToString(folder_ref);
-
-  PThreadFS.init(folder).then(async () => {
-    // Load packaged data added during --pre-js.
-    await PThreadFS.loadAvailablePackages();
-    wasmTable.get(resume)();
-  });
-}
-
-// This is copied from utime() as defined in library.js.
-SyscallWrappers['utime_sync__deps'] = ['$FS', '$setFileTime'];
-SyscallWrappers['utime_sync__proxy'] = 'sync';
-SyscallWrappers['utime_sync__sig'] = 'iii';
-SyscallWrappers['utime_sync'] = function(path, times) {
-  // int utime(const char *path, const struct utimbuf *times);
-  // http://pubs.opengroup.org/onlinepubs/009695399/basedefs/utime.h.html
-  var time;
-  if (times) {
-    // NOTE: We don't keep track of access timestamps.
-    time = {{{ makeGetValue('times', C_STRUCTS.utimbuf.modtime, 'i32') }}} * 1000;
-  } else {
-    time = Date.now();
-  }
-  return setFileTime(path, time);
-};
-
-SyscallWrappers['utime_async'] = function(path, times, resume) {
-  var time;
-  if (times) {
-    // NOTE: We don't keep track of access timestamps.
-    time = {{{ makeGetValue('times', C_STRUCTS.utimbuf.modtime, 'i32') }}} * 1000;
-  } else {
-    time = Date.now();
-  }
-  path = UTF8ToString(path);
-  try {
-    PThreadFS.utime(path, time, time).then(() => {
-      wasmTable.get(resume)(0);
-    });
-  } catch (e) {
-    if (!(e instanceof PThreadFS.ErrnoError)) throw e + ' : ' + stackTrace();
-    setErrNo(e.errno);
-    wasmTable.get(resume)(-1);
-  }
-};
-
 SyscallWrappers['pthreadfs_init'] =
   function(folder_ref, resume) {
   let folder = UTF8ToString(folder_ref);


### PR DESCRIPTION
Upstream Emscripten switched to using musl's utime implementation in
https://github.com/emscripten-core/emscripten/pull/16282. That implementation
bottoms out in utimensat, which PThreadFS implements, so removing the utime
implementation should be safe.

See 4ce946870ccfdc54ef67d81beae8d85efaa96948 for specific change.

Depends on https://github.com/rstz/emscripten-pthreadfs/pull/41.